### PR TITLE
Fix controller so it doesn't depend on globally scoped variables.

### DIFF
--- a/templates/coffeescript/controller.coffee
+++ b/templates/coffeescript/controller.coffee
@@ -1,9 +1,10 @@
 'use strict'
 
 angular.module('<%= grunt.util._.camelize(appname) %>App')
-  .controller '<%= _.classify(name) %>Ctrl', ($scope) ->
+  .controller '<%= _.classify(name) %>Ctrl', ['$scope', ($scope) ->
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',
       'Testacular'
     ]
+  ]

--- a/templates/javascript/controller.js
+++ b/templates/javascript/controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.controller('<%= _.classify(name) %>Ctrl', function($scope) {
+<%= _.camelize(appname) %>App.controller('<%= _.classify(name) %>Ctrl', ['$scope', function($scope) {
   $scope.awesomeThings = [
     'HTML5 Boilerplate',
     'AngularJS',
     'Testacular'
   ];
-});
+}]);


### PR DESCRIPTION
Minification breaks the current default generated app because the controller depends on the global `$scope`. To avoid this people have to either anotate their code or minify with non-standard command line switches.

This change remove the dependency on global variables and uses angulars way of passing the correct scope to the controller.
