### PR TITLE
Adding a warning if testacular it's not installed

### DIFF
--- a/all/index.js
+++ b/all/index.js
@@ -36,6 +36,32 @@ function checkTestacular(){
   try {
     var testacular = require('testacular'),
         colors = require('colors'); //just for syntastic sugar
+
+    //TODO: check a global dependency instead of harcoding it.
+    //also know the minimum usable version. For now using the latest version (0.4.0).
+    function isLowerVersion(current, minimum) {
+      var i, min, cur;
+
+      current = current.split('.');
+      minimum = minimum.split('.');
+
+      for (i in minimum) {
+        cur = parseInt(current[i], 10);
+        min = parseInt(minimum[i], 10);
+        
+        if (cur < min) {
+          return true;
+        } else if (cur > min) {
+          return false;
+        }
+      }
+      return false
+    }
+    if(isLowerVersion(testacular.VERSION, '0.4.0')) {
+      console.log('\n✖ Testacular [outdated]\n'.yellow +
+      '  You\'re ready to go and start using Angular but your testing skills are getting\n'.grey +
+      '  rusty! Update it, run '.grey + 'sudo npm update -g testacular' + ' in your terminal.'.grey);
+    }
   } catch (err) {
     //only bother if it's not installed
     console.log('\n✖ Testacular [not installed]\n'.red +


### PR DESCRIPTION
![Screen Shot 2012-12-10 at 7.25.36 AM.png](https://f.cloud.github.com/assets/745710/3019/16f01dd8-4296-11e2-8edb-eef577f7afd2.png)

Because we're switching the unit test framework and don't check if it's ok to use testacular. Just to solve those cases and reinforce the need to use testacular.

I hope this make sense and feel free to change, comment or cancel the PR.

Iknite.

Ps. I've just signed the CLA in sync of this pull, just to avoid de callback hell ;)
