### PR TITLE
Remove application global from javascripts

### DIFF
--- a/templates/javascript/app.js
+++ b/templates/javascript/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var <%= grunt.util._.camelize(appname) %>App = angular.module('<%= grunt.util._.camelize(appname) %>App', [])
+angular.module('<%= grunt.util._.camelize(appname) %>App', [])
   .config(['$routeProvider', function($routeProvider) {
     $routeProvider
       .when('/', {

--- a/templates/javascript/controller.js
+++ b/templates/javascript/controller.js
@@ -1,6 +1,6 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.controller('<%= _.classify(name) %>Ctrl', function($scope) {
+angular.module('<%= _.camelize(appname) %>App').controller('<%= _.classify(name) %>Ctrl', function($scope) {
   $scope.awesomeThings = [
     'HTML5 Boilerplate',
     'AngularJS',

--- a/templates/javascript/directive.js
+++ b/templates/javascript/directive.js
@@ -1,6 +1,6 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.directive('<%= _.camelize(name) %>', function() {
+angular.module('<%= _.camelize(appname) %>App').directive('<%= _.camelize(name) %>', function() {
   return {
     template: '<div></div>',
     restrict: 'E',

--- a/templates/javascript/filter.js
+++ b/templates/javascript/filter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.filter('<%= _.camelize(name) %>', function() {
+angular.module('<%= _.camelize(appname) %>App').filter('<%= _.camelize(name) %>', function() {
   return function(input) {
     return '<%= _.camelize(name) %> filter: ' + input;
   };

--- a/templates/javascript/service/constant.js
+++ b/templates/javascript/service/constant.js
@@ -1,3 +1,3 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.constant('<%= _.camelize(name) %>', 42);
+angular.module('<%= _.camelize(appname) %>App').constant('<%= _.camelize(name) %>', 42);

--- a/templates/javascript/service/factory.js
+++ b/templates/javascript/service/factory.js
@@ -1,6 +1,6 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.factory('<%= _.camelize(name) %>', function() {
+angular.module('<%= _.camelize(appname) %>App').factory('<%= _.camelize(name) %>', function() {
   // Service logic
   // ...
 

--- a/templates/javascript/service/provider.js
+++ b/templates/javascript/service/provider.js
@@ -1,6 +1,6 @@
 'use strict';
 
-<%= grunt.util._.camelize(appname) %>App.provider('<%= _.camelize(name) %>', function() {
+angular.module('<%= _.camelize(appname) %>App').provider('<%= _.camelize(name) %>', function() {
 
   // Private variables
   var salutation = 'Hello';

--- a/templates/javascript/service/service.js
+++ b/templates/javascript/service/service.js
@@ -1,5 +1,5 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.service('<%= _.camelize(name) %>', function <%= _.camelize(name) %>() {
+angular.module('<%= _.camelize(appname) %>App').service('<%= _.camelize(name) %>', function <%= _.camelize(name) %>() {
   // AngularJS will instantiate a singleton by calling "new" on this function
 });

--- a/templates/javascript/service/value.js
+++ b/templates/javascript/service/value.js
@@ -1,3 +1,3 @@
 'use strict';
 
-<%= _.camelize(appname) %>App.value('<%= _.camelize(name) %>', 42);
+angular.module('<%= _.camelize(appname) %>App').value('<%= _.camelize(name) %>', 42);


### PR DESCRIPTION
Uses the best practice described in ngmin README.

This also makes the generators output compatible with ngmin, which can prepare the code base for minification.
