### PR TITLE
Fixed angular component path

### DIFF
--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -25,7 +25,7 @@
     <!-- Add your site or application content here -->
     <div class="container" ng-view></div>
 
-    <script src="components/AngularJS/angular.js"></script><% if (resourceModule) { %>
+    <script src="components/angular/angular.js"></script><% if (resourceModule) { %>
     <script src="components/angular-resource/angular-resource.js"></script><% } %><% if (cookiesModule) { %>
     <script src="components/angular-cookies/angular-cookies.js"></script><% } %><% if (sanitizeModule) { %>
     <script src="components/angular-sanitize/angular-sanitize.js"></script><% } %>


### PR DESCRIPTION
I might be wrong, but I feel like <a href='https://github.com/yeoman/generator-angular/commit/5c4ac4bee86b771e404b0c471cee71bb3482f8f9#templates/common/index.html'>5c4ac4bee8</a> incorrectly changed the path to angular.js in index.html.
