### PR TITLE
add hostname parameter in grunt livereload config

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -44,6 +44,7 @@ module.exports = function (grunt) {
     connect: {
       livereload: {
         options: {
+          hostname: '0.0.0.0',
           port: 9000,
           middleware: function (connect) {
             return [


### PR DESCRIPTION
to accept connections from other computers.
