### PR TITLE
Update controller.js template so js minify does not cause errors

### DIFF
--- a/templates/javascript/controller.js
+++ b/templates/javascript/controller.js
@@ -1,10 +1,10 @@
 'use strict';
 
 angular.module('<%= _.camelize(appname) %>App')
-  .controller('<%= _.classify(name) %>Ctrl', function ($scope) {
+  .controller('<%= _.classify(name) %>Ctrl', ['$scope', function($scope) {
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',
       'Testacular'
     ];
-  });
+  }]);


### PR DESCRIPTION
Without this, yeoman build causes this error

Generating the cache manifest
  - Command: phantomjs /usr/local/share/npm/lib/node_modules/yeoman/lib/support/confess.js http://localhost:3501 appcache /usr/local/share/npm/lib/node_modules/yeoman/lib/support/confess.json

Writing to manifest.appcache...
# Error: Unknown provider: aProvider <- a

    at http://localhost:3501/scripts/vendor/d10639ae.angular.js:2627
    at getService (http://localhost:3501/scripts/vendor/d10639ae.angular.js:2755)
    at http://localhost:3501/scripts/vendor/d10639ae.angular.js:2632
    at getService (http://localhost:3501/scripts/vendor/d10639ae.angular.js:2755)
    at invoke (http://localhost:3501/scripts/vendor/d10639ae.angular.js:2773)
    at instantiate (http://localhost:3501/scripts/vendor/d10639ae.angular.js:2805)
    at http://localhost:3501/scripts/vendor/d10639ae.angular.js:4620
    at update (http://localhost:3501/scripts/vendor/d10639ae.angular.js:13692)
    at http://localhost:3501/scripts/vendor/d10639ae.angular.js:8002 (undefined, #undefined)
CACHE MANIFEST
