### PR TITLE
Fix `grunt server` for coffeescript angular apps.

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -96,9 +96,11 @@ module.exports = function (grunt) {
     },
     coffee: {
       dist: {
-        files: {
-          '.tmp/scripts/coffee.js': '<%%= yeoman.app %>/scripts/*.coffee'
-        }
+        expand: true,
+        cwd: '<%%= yeoman.app %>/scripts/',
+        src: ['**/*.coffee'],
+        dest: '.tmp/scripts/',
+        ext: '.js'
       },
       test: {
         files: [{


### PR DESCRIPTION
Hi,

I hope I understood issue #81 correctly. Otherwise this is a fix for a different issue _grunt server not working for angular apps bootstrapped with --coffee_

Here's the workflow I followed to replicate the issue:

``` bash
$ npm install generator-angular generator-testacular
$ yo angular gruntServerBreaksWithCoffee --coffee
$ npm install && bower install --dev
$ grunt server
```
## Result

app.js and controllers/main.js not loaded
## Cause

Gruntfile.js coffee task is combining into a single file, the index.html still looks for individuals files. 
## Fix
1. Set files to [glob](http://gruntjs.com/configuring-tasks) 
2. add a *_/_.coffee wildcard search pattern

grunt server now shows the first page
