### PR TITLE
Update editorconfig to use 2 spaces indention

### DIFF
--- a/templates/common/root/.editorconfig
+++ b/templates/common/root/.editorconfig
@@ -9,7 +9,7 @@ root = true
 
 # Change these settings to your own preference
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 # We recommend you to keep these unchanged
 end_of_line = lf


### PR DESCRIPTION
The `.editorconfig` set the indent style to 4 spaces, while the `.jshintrc` and templates were using two spaces.
