### PR TITLE
Fix coffeescript-min controller generation

### DIFF
--- a/templates/coffeescript-min/controller.coffee
+++ b/templates/coffeescript-min/controller.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
-  .controller ['$scope', '<%= _.classify(name) %>Ctrl', ($scope) ->
+  .controller '<%= _.classify(name) %>Ctrl', ['$scope', ($scope) ->
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',


### PR DESCRIPTION
This fixes the wrong parameter order for controllers generated for `--coffee --minsafe` as described in #96 by @noah-freitas.
