### PR TITLE
Fix compiling of CoffeeScript files

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -96,20 +96,20 @@ module.exports = function (grunt) {
     },
     coffee: {
       dist: {
-        files: {
+        files: [{
           expand: true,
           cwd: '<%%= yeoman.app %>/scripts',
-          src: '**/*.coffee',
+          src: '{,*/}*.coffee',
           dest: '.tmp/scripts',
           ext: '.js'
-        }
+        }]
       },
       test: {
         files: [{
           expand: true,
-          cwd: '<%%= yeoman.app %>/scripts',
-          src: '**/*.coffee',
-          dest: '.tmp/scripts',
+          cwd: 'test/spec',
+          src: '{,*/}*.coffee',
+          dest: '.tmp/spec',
           ext: '.js'
         }]
       }
@@ -135,8 +135,8 @@ module.exports = function (grunt) {
       dist: {
         files: {
           '<%%= yeoman.dist %>/scripts/scripts.js': [
-            '.tmp/scripts/**/*.js',
-            '<%%= yeoman.app %>/scripts/**/*.js'
+            '.tmp/scripts/{,*/}*.js',
+            '<%%= yeoman.app %>/scripts/{,*/}*.js'
           ]
         }
       }


### PR DESCRIPTION
CoffeeScript files compiling to **separated** files. And scripts **from subdirectories** compiling too.

Additional information can be found in issue #81

P.S.: to run coffeescript tests, you need add 

``` javascript
    '.tmp/scripts/**/*.js',
    '.tmp/spec/**/*.js'
```

to `files` variable in `testacular.conf.js` (I don't know where this file generated)
