### PR TITLE
Fixed Bower error caused by incorrect templates.

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -81,8 +81,8 @@ module.exports = function (grunt) {
           dot: true,
           src: [
             '.tmp',
-            '<%= yeoman.dist %>/*',
-            '!<%= yeoman.dist %>/.git*'
+            '<%%= yeoman.dist %>/*',
+            '!<%%= yeoman.dist %>/.git*'
           ]
         }]
       },


### PR DESCRIPTION
It looks like 9bade658d65a1b3129aadf60cd896296ade68858 broke the generator because of incorrect templates in `Gruntfile.js`.

``` console
$ node --version
v0.10.1

$ yo --version
1.0.0-beta.3

$ grunt --version
grunt-cli v0.1.6

$ bower --version
0.8.5

$ npm install git://github.com/yeoman/generator-angular.git#9bade658d65a1b3129aadf60cd896296ade68858 generator-karma

$ yo angular
Would you like to include Twitter Bootstrap? (Y/n) n
If so, would you like to use Twitter Bootstrap for Compass (as opposed to vanilla CSS)? (Y/n) n
Would you like to include angular-resource.js? (Y/n) n
Would you like to include angular-cookies.js? (Y/n) n
Would you like to include angular-sanitize.js? (Y/n) n
   create app/index.html

/usr/local/share/npm/lib/node_modules/bower/node_modules/tmp/lib/tmp.js:219
    throw err;
          ^
ReferenceError: yeoman is not defined
    at eval (/lodash/template/source[3]:7:11)
    at Generator.underscore [as _engine] (/test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/util/engines.js:33:30)
    at Generator.engine (/test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/actions/actions.js:195:10)
    at Generator.template (/test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/actions/actions.js:174:15)
    at Generator.packageFiles (/test-project/node_modules/generator-angular/app/index.js:154:8)
    at next (/test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/base.js:275:18)
    at /test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/base.js:286:7
    at next (/test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/util/conflicter.js:52:14)
    at /test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/util/conflicter.js:61:7
    at EventEmitter.collision (/test-project/node_modules/generator-angular/node_modules/yeoman-generator/lib/util/conflicter.js:80:12)
```
