### PR TITLE
Generate angular with yeoman

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -25,7 +25,7 @@ var Generator = module.exports = function Generator() {
     // attempt to detect if user is using CS or not
     // if cml arg provided, use that; else look for the existence of cs
     if (!this.options.coffee &&
-      this.expandFiles(process.cwd() + '/' + this.appPath + '/scripts/**/*.coffee', {}).length > 0) {
+      this.expandFiles(this.appPath + '/scripts/**/*.coffee', {}).length > 0) {
       this.options.coffee = true;
     }
 


### PR DESCRIPTION
Running the following commands:
mkdir test
yo webapp
npm install && bower install
npm install generator-angular generator-karma
yo angular

After run the last command an error occurs:

/usr/local/lib/node_modules/bower/node_modules/tmp/lib/tmp.js:219
    throw err;
          ^
Error: ENOENT, no such file or directory '/Users/murilo/Desktop/test/Users/murilo/Desktop/test/app/scripts/hello.coffee'
    at Object.fs.statSync (fs.js:684:18)
    at /Users/murilo/Desktop/test/node_modules/generator-angular/node_modules/yeoman-generator/lib/actions/file.js:32:15

This pull request solves the problem.

Even knowing the user should not execute `yo webapp` command, with this fix, the command runs normal.
