### PR TITLE
Integrate grunt-rev into build process

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -223,6 +223,18 @@ module.exports = function (grunt) {
         }
       }
     },
+    rev: {
+      dist: {
+        files: {
+          src: [
+            '<%%= yeoman.dist %>/scripts/{,*/}*.js',
+            '<%%= yeoman.dist %>/styles/{,*/}*.css',
+            '<%%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
+            '<%%= yeoman.dist %>/styles/fonts/*'
+          ]
+        }
+      }
+    },
     copy: {
       dist: {
         files: [{
@@ -276,9 +288,10 @@ module.exports = function (grunt) {
     'concat',
     'copy',
     'cdnify',
-    'usemin',
     'ngmin',
-    'uglify'
+    'uglify',
+    'rev',
+    'usemin'
   ]);
 
   grunt.registerTask('default', ['build']);

--- a/templates/common/package.json
+++ b/templates/common/package.json
@@ -19,6 +19,7 @@
     "grunt-bower-hooks": "~0.2.0",
     "grunt-usemin": "~0.1.7",
     "grunt-regarde": "~0.1.1",
+    "grunt-rev": "~0.1.0",
     "grunt-karma": "~0.3.0",
     "grunt-open": "~0.1.0",
     "matchdep": "~0.1.1",


### PR DESCRIPTION
Same as https://github.com/yeoman/generator-webapp/pull/33. I had to rearrange the tasks a little to make this work. `rev` must be happening after every other compilation step except for `usemin`, which uses the revved files.

It worked well in my manual tests. Are there any consequences I could have overlooked?
// @btford @kevva
