### PR TITLE
Use scope = $rootScope.new() instead of scope = {} in spec

### DIFF
--- a/templates/coffeescript-min/spec/controller.coffee
+++ b/templates/coffeescript-min/spec/controller.coffee
@@ -9,8 +9,8 @@ describe 'Controller: <%= _.classify(name) %>Ctrl', () ->
   scope = {}
 
   # Initialize the controller and a mock scope
-  beforeEach inject ($controller) ->
-    scope = {}
+  beforeEach inject ($controller, $rootScope) ->
+    scope = $rootScope.new()
     <%= _.classify(name) %>Ctrl = $controller '<%= _.classify(name) %>Ctrl', {
       $scope: scope
     }

--- a/templates/coffeescript/spec/controller.coffee
+++ b/templates/coffeescript/spec/controller.coffee
@@ -9,8 +9,8 @@ describe 'Controller: <%= _.classify(name) %>Ctrl', () ->
   scope = {}
 
   # Initialize the controller and a mock scope
-  beforeEach inject ($controller) ->
-    scope = {}
+  beforeEach inject ($controller, $rootScope) ->
+    scope = $rootScope.new()
     <%= _.classify(name) %>Ctrl = $controller '<%= _.classify(name) %>Ctrl', {
       $scope: scope
     }

--- a/templates/javascript-min/spec/controller.js
+++ b/templates/javascript-min/spec/controller.js
@@ -9,8 +9,8 @@ describe('Controller: <%= _.classify(name) %>Ctrl', function () {
     scope;
 
   // Initialize the controller and a mock scope
-  beforeEach(inject(function ($controller) {
-    scope = {};
+  beforeEach(inject(function ($controller, $rootScope) {
+    scope = $rootScope.new();
     <%= _.classify(name) %>Ctrl = $controller('<%= _.classify(name) %>Ctrl', {
       $scope: scope
     });

--- a/templates/javascript/spec/controller.js
+++ b/templates/javascript/spec/controller.js
@@ -9,8 +9,8 @@ describe('Controller: <%= _.classify(name) %>Ctrl', function () {
     scope;
 
   // Initialize the controller and a mock scope
-  beforeEach(inject(function ($controller) {
-    scope = {};
+  beforeEach(inject(function ($controller, $rootScope) {
+    scope = $rootScope.new();
     <%= _.classify(name) %>Ctrl = $controller('<%= _.classify(name) %>Ctrl', {
       $scope: scope
     });


### PR DESCRIPTION
Fixes #117
