### PR TITLE
Updated readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,19 +13,12 @@ mkdir my-new-project && cd $_
 
 Then install `generator-angular` and `generator-karma`:
 ```
-mkdir node_modules && npm install generator-angular generator-karma
+npm install -g generator-angular generator-karma
 ```
-
-**Note: The `mkdir node_modules` in the command above ensures that the generators are installed locally for now until global generator installation is an option.**
 
 Run `yo angular`, optionally passing an app name:
 ```
 yo angular [app-name]
-```
-
-Finally, install npm and bower dependencies:
-```
-npm install && bower install --dev
 ```
 
 ## Generators


### PR DESCRIPTION
Use globally installed generators now that Yeoman 1.0.0-beta.4 is out.
Removed manual dependency installation instructions now that we automatically install them 9f95630e0727624c66bdb1dad7f4aa2479edea2f.
