### PR TITLE
Fixes fonts not being copied into build folder

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -252,7 +252,8 @@ module.exports = function (grunt) {
             '*.{ico,txt}',
             '.htaccess',
             'components/**/*',
-            'images/{,*/}*.{gif,webp}'
+            'images/{,*/}*.{gif,webp}',
+            'styles/fonts/*'
           ]
         }]
       }


### PR DESCRIPTION
Currently the fonts are not being copied into the build folder, this just copies them in.
