### PR TITLE
[Gruntfile template] - change all {,*/} to {,**/} so that they can go multiple levels deeper

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -22,23 +22,23 @@ module.exports = function (grunt) {
     yeoman: yeomanConfig,
     watch: {
       coffee: {
-        files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
+        files: ['<%%= yeoman.app %>/scripts/{,**/}*.coffee'],
         tasks: ['coffee:dist']
       },
       coffeeTest: {
-        files: ['test/spec/{,*/}*.coffee'],
+        files: ['test/spec/{,**/}*.coffee'],
         tasks: ['coffee:test']
       },
       compass: {
-        files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+        files: ['<%%= yeoman.app %>/styles/{,**/}*.{scss,sass}'],
         tasks: ['compass']
       },
       livereload: {
         files: [
-          '<%%= yeoman.app %>/{,*/}*.html',
-          '{.tmp,<%%= yeoman.app %>}/styles/{,*/}*.css',
-          '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
-          '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+          '<%%= yeoman.app %>/{,**/}*.html',
+          '{.tmp,<%%= yeoman.app %>}/styles/{,**/}*.css',
+          '{.tmp,<%%= yeoman.app %>}/scripts/{,**/}*.js',
+          '<%%= yeoman.app %>/images/{,**/}*.{png,jpg,jpeg,gif,webp,svg}'
         ],
         tasks: ['livereload']
       }
@@ -95,7 +95,7 @@ module.exports = function (grunt) {
       },
       all: [
         'Gruntfile.js',
-        '<%%= yeoman.app %>/scripts/{,*/}*.js'
+        '<%%= yeoman.app %>/scripts/{,**/}*.js'
       ]
     },
     karma: {
@@ -109,7 +109,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '<%%= yeoman.app %>/scripts',
-          src: '{,*/}*.coffee',
+          src: '{,**/}*.coffee',
           dest: '.tmp/scripts',
           ext: '.js'
         }]
@@ -118,7 +118,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: 'test/spec',
-          src: '{,*/}*.coffee',
+          src: '{,**/}*.coffee',
           dest: '.tmp/spec',
           ext: '.js'
         }]
@@ -145,8 +145,8 @@ module.exports = function (grunt) {
       dist: {
         files: {
           '<%%= yeoman.dist %>/scripts/scripts.js': [
-            '.tmp/scripts/{,*/}*.js',
-            '<%%= yeoman.app %>/scripts/{,*/}*.js'
+            '.tmp/scripts/{,**/}*.js',
+            '<%%= yeoman.app %>/scripts/{,**/}*.js'
           ]
         }
       }
@@ -158,8 +158,8 @@ module.exports = function (grunt) {
       }
     },
     usemin: {
-      html: ['<%%= yeoman.dist %>/{,*/}*.html'],
-      css: ['<%%= yeoman.dist %>/styles/{,*/}*.css'],
+      html: ['<%%= yeoman.dist %>/{,**/}*.html'],
+      css: ['<%%= yeoman.dist %>/styles/{,**/}*.css'],
       options: {
         dirs: ['<%%= yeoman.dist %>']
       }
@@ -169,7 +169,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '<%%= yeoman.app %>/images',
-          src: '{,*/}*.{png,jpg,jpeg}',
+          src: '{,**/}*.{png,jpg,jpeg}',
           dest: '<%%= yeoman.dist %>/images'
         }]
       }
@@ -178,8 +178,8 @@ module.exports = function (grunt) {
       dist: {
         files: {
           '<%%= yeoman.dist %>/styles/main.css': [
-            '.tmp/styles/{,*/}*.css',
-            '<%%= yeoman.app %>/styles/{,*/}*.css'
+            '.tmp/styles/{,**/}*.css',
+            '<%%= yeoman.app %>/styles/{,**/}*.css'
           ]
         }
       }
@@ -233,9 +233,9 @@ module.exports = function (grunt) {
       dist: {
         files: {
           src: [
-            '<%%= yeoman.dist %>/scripts/{,*/}*.js',
-            '<%%= yeoman.dist %>/styles/{,*/}*.css',
-            '<%%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
+            '<%%= yeoman.dist %>/scripts/{,**/}*.js',
+            '<%%= yeoman.dist %>/styles/{,**/}*.css',
+            '<%%= yeoman.dist %>/images/{,**/}*.{png,jpg,jpeg,gif,webp,svg}',
             '<%%= yeoman.dist %>/styles/fonts/*'
           ]
         }
@@ -252,7 +252,7 @@ module.exports = function (grunt) {
             '*.{ico,txt}',
             '.htaccess',
             'components/**/*',
-            'images/{,*/}*.{gif,webp}',
+            'images/{,**/}*.{gif,webp}',
             'styles/fonts/*'
           ]
         }]


### PR DESCRIPTION
The {,*/} wildcard only matches the current level and one level below. For example

```
"/styles/{,*/}*.css"
```

 will match "/styles/foo.css" and "/styles/foo/bar.css" but not "/styles/foo/bar/deep.css"

Changing the wildcard to {,**/} fixes this. 
