### PR TITLE
Fix coffeescript-min directive generation

### DIFF
--- a/templates/coffeescript-min/directive.coffee
+++ b/templates/coffeescript-min/directive.coffee
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('<%= _.camelize(appname) %>App')
-  .directive('<%= _.camelize(name) %>', [() ->
+  .directive '<%= _.camelize(name) %>', [() ->
     template: '<div></div>'
     restrict: 'E'
     link: (scope, element, attrs) ->


### PR DESCRIPTION
Removing extra parenthesis causing compilation failure.
