### PR TITLE
style (Gruntfile.js) Remove extra comma in Gruntfile

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -301,7 +301,7 @@ module.exports = function (grunt) {
           ]
         }
       }
-    },
+    }
   });
 
   grunt.registerTask('server', function (target) {


### PR DESCRIPTION
Remove extra comma from Gruntfile. Not needed for nodejs to run it but
jshint warns about it when running "grunt"
