### PR TITLE
Add NPM >=1.2.10 as engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "grunt-release": "~0.3.3"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.8.0",
+    "npm": ">=1.2.10"
   },
   "licenses": [
     {


### PR DESCRIPTION
From https://github.com/yeoman/generator-webapp/pull/100, this advises a user Yo and the generators require NPM >= 1.2.10, when peerDependencies support was introduced.
