### PR TITLE
Add explicit instruction for dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,9 @@ Based on [angular-seed](https://github.com/angular/angular-seed/)
 
 ## Usage
 
-Install `generator-angular`:
+Install `yeoman` & `generator-angular`:
 ```
-npm install -g generator-angular
+npm install -g yo generator-angular
 ```
 
 Make a new directory, and `cd` into it:


### PR DESCRIPTION
Prevent confusion for people whose foray into yeoman begins with using angular-generator.

Some people may assume that angular-generator installs the dependency for them. This prevents them from thinking there's a path issue when they receive "yo: command not found"
