### PR TITLE
fix(app): 404 on Bootstrap Images

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -137,6 +137,8 @@ Generator.prototype.bootstrapFiles = function bootstrapFiles() {
   } else {
     if (this.bootstrap) {
       files.push('bootstrap.css');
+        this.copy('images/glyphicons-halflings.png', 'app/images/glyphicons-halflings.png');
+        this.copy('images/glyphicons-halflings-white.png', 'app/images/glyphicons-halflings-white.png');
     }
 
     files.push('main.css');

--- a/app/templates/styles/scss/main.scss
+++ b/app/templates/styles/scss/main.scss
@@ -1,3 +1,6 @@
+$iconSpritePath: "../images/glyphicons-halflings.png";
+$iconWhiteSpritePath: "../images/glyphicons-halflings-white.png";
+
 @import "bootstrap-sass/lib/bootstrap";
 
 /* Put your CSS here */


### PR DESCRIPTION
Add lines of code to allow the glyphicons to not have 404 errors.
Followed the standard of the generator-yeoman-webapp for consistency.
