### PR TITLE
feat(app): add jshintrc for testing folder

### DIFF
--- a/templates/common/root/test/.jshintrc
+++ b/templates/common/root/test/.jshintrc
@@ -1,0 +1,35 @@
+{
+  "node": true,
+  "browser": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true,
+  "globals": {
+    "after": false,
+    "afterEach": false,
+    "angular": false,
+    "before": false,
+    "beforeEach": false,
+    "browser": false,
+    "describe": false,
+    "expect": false,
+    "inject": false,
+    "it": false,
+    "spyOn": false
+  }
+}
+


### PR DESCRIPTION
Since jshint now supports nested configuration files, I thought it might be a good idea to have a separate jshintrc for the tests that whitelists the jasmine and AngularJS globals. Is there anything else that should be adjusted?
