### PR TITLE
fix(app): add jQuery <script> into index.html template

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -164,7 +164,6 @@ Generator.prototype.bootstrapJS = function bootstrapJS() {
 
   // Wire Twitter Bootstrap plugins
   this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
-    'bower_components/jquery/jquery.js',
     'bower_components/bootstrap-sass/js/bootstrap-affix.js',
     'bower_components/bootstrap-sass/js/bootstrap-alert.js',
     'bower_components/bootstrap-sass/js/bootstrap-dropdown.js',

--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -32,6 +32,7 @@
       s.parentNode.insertBefore(g,s)}(document,'script'));
     </script>
 
+    <script src="bower_components/jquery/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
 
     <!-- build:js scripts/scripts.js -->


### PR DESCRIPTION
Since jQuery is always included, regardless of answers from the prompt, I've included it in the `index.html` template. I also placed it before angular.js, allowing Angular to use jQuery, and not jqLite. The cdnify task then picks it up.

This helps solves issues like: http://pastebin.com/zxNQuVFR

I'm surprised this hasn't come up before, which makes me feel like I'm doing something silly.
