### PR TITLE
adding grunt-angular-templates to the build tasks

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -262,8 +262,12 @@ module.exports = function (grunt) {
     usemin: {
       html: ['<%%= yeoman.dist %>/{,*/}*.html'],
       css: ['<%%= yeoman.dist %>/styles/{,*/}*.css'],
+      js: ['<%= yeoman.dist %>/scripts/{,*/}*.js'],
       options: {
-        assetsDirs: ['<%%= yeoman.dist %>']
+        assetsDirs: ['<%%= yeoman.dist %>'],
+        patterns: {
+          js: [[/(images\/[^''""]*\.(png|jpg|jpeg|gif|webp|svg))/g, 'Replacing references to images']]
+        }
       }
     },
 
@@ -307,7 +311,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '<%%= yeoman.dist %>',
-          src: ['*.html', 'views/{,*/}*.html'],
+          src: ['*.html'],
           dest: '<%%= yeoman.dist %>'
         }]
       }
@@ -346,7 +350,6 @@ module.exports = function (grunt) {
             '*.{ico,png,txt}',
             '.htaccess',
             '*.html',
-            'views/{,*/}*.html',
             'images/{,*/}*.{webp}',
             'fonts/*'
           ]
@@ -384,6 +387,20 @@ module.exports = function (grunt) {
         'imagemin',
         'svgmin'
       ]
+    },
+
+    // Convert Angular HTML view files to JavaScript cached versions
+    ngtemplates: {
+      dist: {
+        options: {
+          module: '<%= scriptAppName %>',
+          htmlmin: '<%%= htmlmin.dist.options %>',
+          usemin: '<%%= yeoman.dist %>/scripts/scripts.js'
+        },
+        cwd: '<%%= yeoman.app %>',
+        src: 'views/{,*/}*.html',
+        dest: '.tmp/scripts/templateCache.js'
+      }
     },
 
     // By default, your `index.html`'s <!-- Usemin block --> will take care of
@@ -455,6 +472,7 @@ module.exports = function (grunt) {
     'bowerInstall',
     'useminPrepare',
     'concurrent:dist',
+    'ngtemplates',
     'autoprefixer',
     'concat',
     'ngmin',

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -4,6 +4,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-angular-templates": "~0.5.3",
     "grunt-autoprefixer": "~0.4.0",
     "grunt-bower-install": "~1.0.0",
     "grunt-concurrent": "~0.5.0",


### PR DESCRIPTION
Hello everyone,

The package 'grunt-angular-templates' could be a great task to add to the build process. 
It concatenates all html templates and registers them in the templateCache, which proves to be a massive performance improvement (no more need to request html partials when needed).

More info here:
- https://npmjs.org/package/grunt-angular-templates
- https://github.com/ericclemmons/grunt-angular-templates

I am not very confident about my implementation, but it is working fine on my end, so I still open the PR.