### PR TITLE
fix(app): order of script inclusions

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -205,6 +205,16 @@ Generator.prototype.extraModules = function extraModules() {
   }
 };
 
+Generator.prototype.appJs = function appJs() {
+  this.indexFile = this.appendFiles({
+    html: this.indexFile,
+    fileType: 'js',
+    optimizedPath: 'scripts/scripts.js',
+    sourceFileList: ['scripts/app.js', 'scripts/controllers/main.js'],
+    searchPath: ['.tmp', 'app']
+  });
+};
+
 Generator.prototype.createIndexHtml = function createIndexHtml() {
   this.write(path.join(this.appPath, 'index.html'), this.indexFile);
 };

--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -34,10 +34,5 @@
 
     <script src="bower_components/jquery/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
-
-    <!-- build:js({.tmp,app}) scripts/scripts.js -->
-    <script src="scripts/app.js"></script>
-    <script src="scripts/controllers/main.js"></script>
-    <!-- endbuild -->
   </body>
 </html>


### PR DESCRIPTION
Fixes #278

The application JS is now included as last element in the `index.html`, specifically after any plugins. As a consequence, the subgenerators append their own snippets in the same block.
