### PR TITLE
Removing the extra semi-colon, it is not needed for coffee script.

### DIFF
--- a/templates/coffeescript-min/spec/controller.coffee
+++ b/templates/coffeescript-min/spec/controller.coffee
@@ -16,4 +16,4 @@ describe 'Controller: <%= _.classify(name) %>Ctrl', () ->
     }
 
   it 'should attach a list of awesomeThings to the scope', () ->
-    expect(scope.awesomeThings.length).toBe 3;
+    expect(scope.awesomeThings.length).toBe 3

--- a/templates/coffeescript-min/spec/filter.coffee
+++ b/templates/coffeescript-min/spec/filter.coffee
@@ -12,4 +12,4 @@ describe 'Filter: <%= _.camelize(name) %>', () ->
 
   it 'should return the input prefixed with "<%= _.camelize(name) %> filter:"', () ->
     text = 'angularjs'
-    expect(<%= _.camelize(name) %> text).toBe ('<%= _.camelize(name) %> filter: ' + text);
+    expect(<%= _.camelize(name) %> text).toBe ('<%= _.camelize(name) %> filter: ' + text)

--- a/templates/coffeescript-min/spec/service.coffee
+++ b/templates/coffeescript-min/spec/service.coffee
@@ -11,4 +11,4 @@ describe 'Service: <%= _.camelize(name) %>', () ->
     <%= _.camelize(name) %> = _<%= _.camelize(name) %>_
 
   it 'should do something', () ->
-    expect(!!<%= _.camelize(name) %>).toBe true;
+    expect(!!<%= _.camelize(name) %>).toBe true

--- a/templates/coffeescript/spec/controller.coffee
+++ b/templates/coffeescript/spec/controller.coffee
@@ -16,4 +16,4 @@ describe 'Controller: <%= _.classify(name) %>Ctrl', () ->
     }
 
   it 'should attach a list of awesomeThings to the scope', () ->
-    expect(scope.awesomeThings.length).toBe 3;
+    expect(scope.awesomeThings.length).toBe 3

--- a/templates/coffeescript/spec/filter.coffee
+++ b/templates/coffeescript/spec/filter.coffee
@@ -12,4 +12,4 @@ describe 'Filter: <%= _.camelize(name) %>', () ->
 
   it 'should return the input prefixed with "<%= _.camelize(name) %> filter:"', () ->
     text = 'angularjs'
-    expect(<%= _.camelize(name) %> text).toBe ('<%= _.camelize(name) %> filter: ' + text);
+    expect(<%= _.camelize(name) %> text).toBe ('<%= _.camelize(name) %> filter: ' + text)

--- a/templates/coffeescript/spec/service.coffee
+++ b/templates/coffeescript/spec/service.coffee
@@ -11,4 +11,4 @@ describe 'Service: <%= _.camelize(name) %>', () ->
     <%= _.camelize(name) %> = _<%= _.camelize(name) %>_
 
   it 'should do something', () ->
-    expect(!!<%= _.camelize(name) %>).toBe true;
+    expect(!!<%= _.camelize(name) %>).toBe true


### PR DESCRIPTION
Signed-off-by: Rocky Jaiswal rocky.jaiswal@gmail.com
