### PR TITLE
Use a new scope instead of $rootScope for directive specs

### DIFF
--- a/templates/coffeescript-min/spec/directive.coffee
+++ b/templates/coffeescript-min/spec/directive.coffee
@@ -1,11 +1,16 @@
 'use strict'
 
 describe 'Directive: <%= _.camelize(name) %>', () ->
+
+  # load the directive's module
   beforeEach module '<%= _.camelize(appname) %>App'
 
-  element = {}
+  scope = {}
 
-  it 'should make hidden element visible', inject ($rootScope, $compile) ->
+  beforeEach inject ($controller, $rootScope) ->
+    scope = $rootScope.$new()
+
+  it 'should make hidden element visible', inject ($compile) ->
     element = angular.element '<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>'
-    element = $compile(element) $rootScope
+    element = $compile(element) scope
     expect(element.text()).toBe 'this is the <%= _.camelize(name) %> directive'

--- a/templates/coffeescript/spec/directive.coffee
+++ b/templates/coffeescript/spec/directive.coffee
@@ -1,11 +1,16 @@
 'use strict'
 
 describe 'Directive: <%= _.camelize(name) %>', () ->
+
+  # load the directive's module
   beforeEach module '<%= _.camelize(appname) %>App'
 
-  element = {}
+  scope = {}
 
-  it 'should make hidden element visible', inject ($rootScope, $compile) ->
+  beforeEach inject ($controller, $rootScope) ->
+    scope = $rootScope.$new()
+
+  it 'should make hidden element visible', inject ($compile) ->
     element = angular.element '<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>'
-    element = $compile(element) $rootScope
+    element = $compile(element) scope
     expect(element.text()).toBe 'this is the <%= _.camelize(name) %> directive'

--- a/templates/javascript-min/spec/directive.js
+++ b/templates/javascript-min/spec/directive.js
@@ -1,13 +1,20 @@
 'use strict';
 
 describe('Directive: <%= _.camelize(name) %>', function () {
+
+  // load the directive's module
   beforeEach(module('<%= _.camelize(appname) %>App'));
 
-  var element;
+  var element,
+    scope;
 
-  it('should make hidden element visible', inject(function ($rootScope, $compile) {
+  beforeEach(inject(function ($rootScope) {
+    scope = $rootScope.$new();
+  }));
+
+  it('should make hidden element visible', inject(function ($compile) {
     element = angular.element('<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>');
-    element = $compile(element)($rootScope);
+    element = $compile(element)(scope);
     expect(element.text()).toBe('this is the <%= _.camelize(name) %> directive');
   }));
 });

--- a/templates/javascript/spec/directive.js
+++ b/templates/javascript/spec/directive.js
@@ -1,13 +1,20 @@
 'use strict';
 
 describe('Directive: <%= _.camelize(name) %>', function () {
+
+  // load the directive's module
   beforeEach(module('<%= _.camelize(appname) %>App'));
 
-  var element;
+  var element,
+    scope;
 
-  it('should make hidden element visible', inject(function ($rootScope, $compile) {
+  beforeEach(inject(function ($rootScope) {
+    scope = $rootScope.$new();
+  }));
+
+  it('should make hidden element visible', inject(function ($compile) {
     element = angular.element('<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>');
-    element = $compile(element)($rootScope);
+    element = $compile(element)(scope);
     expect(element.text()).toBe('this is the <%= _.camelize(name) %> directive');
   }));
 });


### PR DESCRIPTION
To mirror the controller spec template, the generated tests for directives
mock a new scope instead of working directly on the $rootScope with this patch.

/cc @stephenplusplus @btford
