### PR TITLE
Replace ga.js with analytics.js

### DIFF
--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -24,14 +24,14 @@
     <!-- Add your site or application content here -->
     <div class="container" ng-view></div>
 
-    <!-- Google Analytics: change UA-XXXXX-X to be your site's ID and DOMAIN to your site's domain. -->
+    <!-- Google Analytics: change UA-XXXXX-X to be your site's ID -->
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-XXXXX-X', 'DOMAIN');
+      ga('create', 'UA-XXXXX-X');
       ga('send', 'pageview');
 
     </script>


### PR DESCRIPTION
According to the Analytics team new users should use analytics.js rather than the older ga.js.  I think we should probably have new applications created with this generator default to that script rather than the older one.

https://developers.google.com/analytics/devguides/collection/analyticsjs/
