### PR TITLE
fix: add CNAME to copy task

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -274,7 +274,8 @@ module.exports = function (grunt) {
             '.htaccess',
             'bower_components/**/*',
             'images/{,*/}*.{gif,webp}',
-            'styles/fonts/*'
+            'styles/fonts/*',
+            'CNAME'
           ]
         }, {
           expand: true,


### PR DESCRIPTION
CNAME file is used on Github Pages to specify domain names for pages. Copy
task now copies CNAME file.
