### PR TITLE
Fix(readme) Added link to angular:provider etc. under ###Generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,10 @@ Available generators:
 * [angular:filter](#filter)
 * [angular:route](#route)
 * [angular:service](#service)
+* [angular:provider](#service)
+* [angular:factory](#service)
+* [angular:value](#service)
+* [angular:constant](#service)
 * [angular:decorator] (#decorator)
 * [angular:view](#view)
 


### PR DESCRIPTION
The presence of additional generators is hidden under ### Service
