### PR TITLE
Compatibility downgrade of "grunt-contrib-imagemin"

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-connect": "~0.3.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-contrib-imagemin": "~0.2.0",
+    "grunt-contrib-imagemin": "~0.1.4",
     "grunt-contrib-watch": "~0.5.2",
     "grunt-autoprefixer": "~0.2.0",
     "grunt-usemin": "~0.1.11",


### PR DESCRIPTION
Same problem here: https://github.com/yeoman/generator-webapp/issues/140

I'm always getting those dialog windows when running a clean `yo angular` installation. That's a bit too much "dependency" for me...

![screen shot 2013-08-24 at 10 31 38 pm](https://f.cloud.github.com/assets/1567498/1021389/b0914044-0cfc-11e3-88d3-14ac49ecebff.png)

![screen shot 2013-08-24 at 10 36 18 pm](https://f.cloud.github.com/assets/1567498/1021390/df372efe-0cfc-11e3-921c-0690be9cd524.png)
