### PR TITLE
Angular generator creating wrong path for view if creating route with path having ('/')

### DIFF
--- a/view/index.js
+++ b/view/index.js
@@ -21,9 +21,6 @@ function Generator() {
 util.inherits(Generator, yeoman.generators.NamedBase);
 
 Generator.prototype.createViewFiles = function createViewFiles() {
-  var targetPath = this.name;
-  if (this.name.indexOf('/') === -1) {
-    targetPath = 'views/' + targetPath;
-  }
+  var targetPath = 'views/' + targetPath;
   this.template('common/view.html', path.join(this.env.options.appPath, targetPath + '.html'));
 };


### PR DESCRIPTION
Hello,
I have found a bug in view/index.js at below code
if (this.name.indexOf('/') === -1) {
targetPath = 'views/' + targetPath;
}
*\* now the scenario is that; I am creating a route with path: 'setting/user/group/create'
it creates all the entries in app.js and create controllers in right way. But the Html has been created in the folder out side the /views, because as per the above code the route i have created has '/' in it.
so the above code need to be changed. I tried by deleting the above code on my local and it is working fine.

Please let me know in case any input is required from my side
