### PR TITLE
fix(templates): correct coffee provider template

### DIFF
--- a/templates/coffeescript-min/service/provider.coffee
+++ b/templates/coffeescript-min/service/provider.coffee
@@ -12,10 +12,10 @@ angular.module('<%= _.camelize(appname) %>App')
         salutation
 
     # Public API for configuration
-    @.setSalutation = (s) ->
+    @setSalutation = (s) ->
       salutation = s
 
     # Method for instantiating
-    @.$get = () ->
+    @$get = ->
       new Greeter()
   ]

--- a/templates/coffeescript/service/provider.coffee
+++ b/templates/coffeescript/service/provider.coffee
@@ -12,10 +12,10 @@ angular.module('<%= _.camelize(appname) %>App')
         salutation
 
     # Public API for configuration
-    @.setSalutation = (s) ->
+    @setSalutation = (s) ->
       salutation = s
 
     # Method for instantiating
-    @.$get = () ->
+    @$get = ->
       new Greeter()
   ]


### PR DESCRIPTION
The current coffee script template has a syntax error that prevents it from being converted into javascript.  In addition, the current template produces a skeleton provider which doesn't pass a "grunt test" out of the box.  This pull request fixes the syntax error and corrects the coffee script code to produce a skeleton that passes the sample test out of the box.  It also tweaks the syntax of the coffee script to fall in line with general practices. 
