### PR TITLE
refactor(app): Simplify subgenerator code

### DIFF
--- a/constant/index.js
+++ b/constant/index.js
@@ -1,8 +1,6 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
-var angularUtils = require('../util.js');
 
 
 var Generator = module.exports = function Generator() {
@@ -12,7 +10,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.appTemplate('service/constant', 'scripts/services/' + this.name);
-  this.testTemplate('spec/service', 'services/' + this.name);
-  this.addScriptToIndex('services/' + this.name);
+  this.generateSourceAndTest('service/constant', 'spec/service', 'services');
 };

--- a/controller/index.js
+++ b/controller/index.js
@@ -1,5 +1,4 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
 
@@ -17,7 +16,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createControllerFiles = function createControllerFiles() {
-  this.appTemplate('controller', 'scripts/controllers/' + this.name);
-  this.testTemplate('spec/controller', 'controllers/' + this.name);
-  this.addScriptToIndex('controllers/' + this.name);
+  this.generateSourceAndTest('controller', 'spec/controller', 'controllers');
 };

--- a/directive/index.js
+++ b/directive/index.js
@@ -1,8 +1,6 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
-var angularUtils = require('../util.js');
 
 
 var Generator = module.exports = function Generator() {
@@ -12,7 +10,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createDirectiveFiles = function createDirectiveFiles() {
-  this.appTemplate('directive', 'scripts/directives/' + this.name);
-  this.testTemplate('spec/directive', 'directives/' + this.name);
-  this.addScriptToIndex('directives/' + this.name);
+  this.generateSourceAndTest('directive', 'spec/directive', 'directives');
 };

--- a/factory/index.js
+++ b/factory/index.js
@@ -1,8 +1,6 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
-var angularUtils = require('../util.js');
 
 
 var Generator = module.exports = function Generator() {
@@ -12,7 +10,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.appTemplate('service/factory', 'scripts/services/' + this.name);
-  this.testTemplate('spec/service', 'services/' + this.name);
-  this.addScriptToIndex('services/' + this.name);
+  this.generateSourceAndTest('service/factory', 'spec/service', 'services');
 };

--- a/filter/index.js
+++ b/filter/index.js
@@ -1,8 +1,6 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
-var angularUtils = require('../util.js');
 
 
 var Generator = module.exports = function Generator() {
@@ -12,7 +10,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createFilterFiles = function createFilterFiles() {
-  this.appTemplate('filter', 'scripts/filters/' + this.name);
-  this.testTemplate('spec/filter', 'filters/' + this.name);
-  this.addScriptToIndex('filters/' + this.name);
+  this.generateSourceAndTest('filter', 'spec/filter', 'filters');
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "load-grunt-tasks": "~0.1.0",
     "marked": "~0.2.8",
     "semver": "~2.1.0",
+    "underscore.string": "~2.3.1",
     "grunt-release": "~0.5.1"
   },
   "engines": {

--- a/provider/index.js
+++ b/provider/index.js
@@ -1,8 +1,6 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
-var angularUtils = require('../util.js');
 
 
 var Generator = module.exports = function Generator() {
@@ -12,7 +10,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.appTemplate('service/provider', 'scripts/services/' + this.name);
-  this.testTemplate('spec/service', 'services/' + this.name);
-  this.addScriptToIndex('services/' + this.name);
+  this.generateSourceAndTest('service/provider', 'spec/service', 'services');
 };

--- a/script-base.js
+++ b/script-base.js
@@ -98,3 +98,9 @@ Generator.prototype.addScriptToIndex = function (script) {
     console.log('\nUnable to find '.yellow + fullPath + '. Reference to '.yellow + script + '.js ' + 'not added.\n'.yellow);
   }
 };
+
+Generator.prototype.generateSourceAndTest = function (appTemplate, testTemplate, targetDirectory) {
+  this.appTemplate(appTemplate, path.join('scripts', targetDirectory, this.name));
+  this.testTemplate(testTemplate, path.join(targetDirectory, this.name));
+  this.addScriptToIndex(path.join(targetDirectory, this.name));
+};

--- a/service/index.js
+++ b/service/index.js
@@ -1,8 +1,6 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
-var angularUtils = require('../util.js');
 
 
 var Generator = module.exports = function Generator() {
@@ -12,7 +10,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.appTemplate('service/service', 'scripts/services/' + this.name);
-  this.testTemplate('spec/service', 'services/' + this.name);
-  this.addScriptToIndex('services/' + this.name);
+  this.generateSourceAndTest('service/service', 'spec/service', 'services');
 };

--- a/value/index.js
+++ b/value/index.js
@@ -1,8 +1,6 @@
 'use strict';
-var path = require('path');
 var util = require('util');
 var ScriptBase = require('../script-base.js');
-var angularUtils = require('../util.js');
 
 
 var Generator = module.exports = function Generator() {
@@ -12,7 +10,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.appTemplate('service/value', 'scripts/services/' + this.name);
-  this.testTemplate('spec/service', 'services/' + this.name);
-  this.addScriptToIndex('services/' + this.name);
+  this.generateSourceAndTest('service/value', 'spec/service', 'services');
 };


### PR DESCRIPTION
Add a common function in the base script to simplify the common tasks
for many of the generators (services, filter, directive, controller).
Also remove some unused modules from the sub-generators (path and angularUtils).

Basically, I moved a lot of duplicated code to a common function in the base script. Since many of the sub-generators use the same pattern (add Source, add Test, add to index.html), a good chunk of code was duplicated across the generators. A common function in the base script covers this nicely and simplifies the sub-generators a good deal.

No need to update tests or documentation, since it's a purely internal change.
