### PR TITLE
fix(grunt): sets port for test server

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -75,6 +75,7 @@ module.exports = function (grunt) {
       },
       test: {
         options: {
+         port: 9001,
           base: [
             '.tmp',
             'test',


### PR DESCRIPTION
Update the template file to have the test port be different from the 
server port so you can run tests with the server running

Closes #375
