### PR TITLE
fix(templates): take out semicolons in coffeescript

### DIFF
--- a/templates/coffeescript-min/decorator.coffee
+++ b/templates/coffeescript-min/decorator.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module("<%= _.camelize(appname) %>App").config ["$provide", ($provide) ->
   $provide.decorator "<%= _.camelize(name) %>", ($delegate) ->

--- a/templates/coffeescript-min/directive.coffee
+++ b/templates/coffeescript-min/directive.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .directive '<%= _.camelize(name) %>', [->

--- a/templates/coffeescript-min/filter.coffee
+++ b/templates/coffeescript-min/filter.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .filter '<%= _.camelize(name) %>', [() ->

--- a/templates/coffeescript-min/service/factory.coffee
+++ b/templates/coffeescript-min/service/factory.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .factory '<%= _.camelize(name) %>', [() ->
@@ -10,6 +10,6 @@ angular.module('<%= _.camelize(appname) %>App')
     # Public API here
     {
       someMethod: () ->
-        meaningOfLife;
+        meaningOfLife
     }
   ]

--- a/templates/coffeescript-min/service/service.coffee
+++ b/templates/coffeescript-min/service/service.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .service '<%= _.classify(name) %>', () ->

--- a/templates/coffeescript-min/service/value.coffee
+++ b/templates/coffeescript-min/service/value.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .value '<%= _.camelize(name) %>', 42

--- a/templates/coffeescript/decorator.coffee
+++ b/templates/coffeescript/decorator.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module("<%= _.camelize(appname) %>App").config ($provide) ->
   $provide.decorator "<%= _.camelize(name) %>", ($delegate) ->

--- a/templates/coffeescript/directive.coffee
+++ b/templates/coffeescript/directive.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .directive('<%= _.camelize(name) %>', () ->

--- a/templates/coffeescript/filter.coffee
+++ b/templates/coffeescript/filter.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .filter '<%= _.camelize(name) %>', () ->

--- a/templates/coffeescript/service/factory.coffee
+++ b/templates/coffeescript/service/factory.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .factory '<%= _.camelize(name) %>', () ->
@@ -10,5 +10,5 @@ angular.module('<%= _.camelize(appname) %>App')
     # Public API here
     {
       someMethod: () ->
-        meaningOfLife;
+        meaningOfLife
     }

--- a/templates/coffeescript/service/service.coffee
+++ b/templates/coffeescript/service/service.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .service '<%= _.classify(name) %>', () ->

--- a/templates/coffeescript/service/value.coffee
+++ b/templates/coffeescript/service/value.coffee
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 angular.module('<%= _.camelize(appname) %>App')
   .value '<%= _.camelize(name) %>', 42


### PR DESCRIPTION
Just some quick `sed` work to get rid of invalid semis.
