### PR TITLE
fix(app): test setup in default configuration

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -52,19 +52,34 @@ var Generator = module.exports = function Generator(args, options) {
     args: args
   });
 
-  this.hookFor('karma', {
-    as: 'app',
-    options: {
+  this.on('end', function () {
+    this.installDependencies({ skipInstall: this.options['skip-install'] });
+
+    var enabledComponents = [];
+
+    if (this.resourceModule) {
+      enabledComponents.push('angular-resource/angular-resource.js');
+    }
+
+    if (this.cookiesModule) {
+      enabledComponents.push('angular-cookies/angular-cookies.js');
+    }
+
+    if (this.sanitizeModule) {
+      enabledComponents.push('angular-sanitize/angular-sanitize.js');
+    }
+
+    this.invoke('karma:app', {
       options: {
         coffee: this.options.coffee,
         travis: true,
-        'skip-install': this.options['skip-install']
-       }
-    }
-  });
-
-  this.on('end', function () {
-    this.installDependencies({ skipInstall: this.options['skip-install'] });
+        'skip-install': this.options['skip-install'],
+        components: [
+          'angular/angular.js',
+          'angular-mocks/angular-mocks.js'
+        ].concat(enabledComponents)
+      }
+    });
   });
 
   this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "yeoman-generator": "~0.13.0"
   },
   "peerDependencies": {
-    "generator-karma": "~0.5.0",
+    "generator-karma": "~0.6.0",
     "yo": ">=1.0.0-rc.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Since modules selected during the scaffolding process are now automatically
added to app dependencies, test would fail because karma didn't have an option
to load additional modules. With generator-karma 0.6 I added an option to load
additional bower components which this generator now makes use of when calling
`hookFor`.

Couldn't extensively test this, because coffee shop Wifi sucks. Could someone else give it a try?

Side note: We should add a data structure to map selected modules to bower components and files to include to get rid of those if-chains, especially considering that there will be even more modules with AngularJS 1.2.
