### PR TITLE
added --js option to override autodetector when cs files are found

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -27,6 +27,10 @@ var Generator = module.exports = function Generator() {
     this.env.options.testPath = this.env.options.testPath || 'test/spec';
   }
 
+  if (typeof this.env.options.js === 'undefined') {
+    this.option('js');
+  }
+
   this.env.options.coffee = this.options.coffee;
   if (typeof this.env.options.coffee === 'undefined') {
     this.option('coffee');
@@ -34,6 +38,7 @@ var Generator = module.exports = function Generator() {
     // attempt to detect if user is using CS or not
     // if cml arg provided, use that; else look for the existence of cs
     if (!this.options.coffee &&
+      !this.options.js &&
       this.expandFiles(path.join(this.env.options.appPath, '/scripts/**/*.coffee'), {}).length > 0) {
       this.options.coffee = true;
     }


### PR DESCRIPTION
The generator detects if there are Coffeescript files in the /scripts directory. However, if one is following a guideline like this: http://briantford.com/blog/huuuuuge-angular-apps.html, wherein there are vendor directories inside the scripts directory that contain coffeescript files, then system should not assume that the user would like to create a coffeescript controller, etc.

I have added a --js option, unless, it is preferable to exclude vendors/ from the expanded search.
