### PR TITLE
fix(docs): Add coffeescript=false to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,9 @@ angular.module('myMod')
 
 A project can mix CoffeScript and JavaScript files.
 
+To output JavaScript files, even if CoffeeScript files exist (the default is to output CoffeeScript files if 
+the generator finds any in the project), use `--coffee=false`.
+
 ### Minification Safe
 By default, generators produce unannotated code. Without annotations, AngularJS's DI system will break when minified. Typically, these annotations that make minification safe are added automatically at build-time, after application files are concatenated, but before they are minified. By providing the `--minsafe` option, the code generated will out-of-the-box be ready for minification. The trade-off is between amount of boilerplate, and build process complexity.
 


### PR DESCRIPTION
The README now shows the --coffee=false option
