### PR TITLE
feat(gen): add option to not add to index

### DIFF
--- a/constant/index.js
+++ b/constant/index.js
@@ -10,5 +10,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.generateSourceAndTest('service/constant', 'spec/service', 'services');
+  this.generateSourceAndTest(
+    'service/constant',
+    'spec/service',
+    'services',
+    this.options['skip-add'] || false
+  );
 };

--- a/controller/index.js
+++ b/controller/index.js
@@ -16,5 +16,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createControllerFiles = function createControllerFiles() {
-  this.generateSourceAndTest('controller', 'spec/controller', 'controllers');
+  this.generateSourceAndTest(
+    'controller',
+    'spec/controller',
+    'controllers',
+    this.options['skip-add'] || false
+  );
 };

--- a/directive/index.js
+++ b/directive/index.js
@@ -10,5 +10,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createDirectiveFiles = function createDirectiveFiles() {
-  this.generateSourceAndTest('directive', 'spec/directive', 'directives');
+  this.generateSourceAndTest(
+    'directive',
+    'spec/directive',
+    'directives',
+    this.options['skip-add'] || false
+  );
 };

--- a/factory/index.js
+++ b/factory/index.js
@@ -10,5 +10,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.generateSourceAndTest('service/factory', 'spec/service', 'services');
+  this.generateSourceAndTest(
+    'service/factory',
+    'spec/service',
+    'services',
+    this.options['skip-add'] || false
+  );
 };

--- a/filter/index.js
+++ b/filter/index.js
@@ -10,5 +10,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createFilterFiles = function createFilterFiles() {
-  this.generateSourceAndTest('filter', 'spec/filter', 'filters');
+  this.generateSourceAndTest(
+    'filter',
+    'spec/filter',
+    'filters',
+    this.options['skip-add'] || false
+  );
 };

--- a/provider/index.js
+++ b/provider/index.js
@@ -10,5 +10,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.generateSourceAndTest('service/provider', 'spec/service', 'services');
+  this.generateSourceAndTest(
+    'service/provider',
+    'spec/service',
+    'services',
+    this.options['skip-add'] || false
+  );
 };

--- a/readme.md
+++ b/readme.md
@@ -224,6 +224,18 @@ The annotations are important because minified code will rename variables, makin
 
 The recommended build process uses `ngmin`, a tool that automatically adds these annotations. However, if you'd rather not use `ngmin`, you have to add these annotations manually yourself.
 
+### Add to Index
+By default, new scripts are added to the index.html file. However, this may not always be suitable. Some use cases:
+
+* Manually added to the file
+* Auto-added by a 3rd party plugin
+* Using this generator as a subgenerator
+
+To skip adding them to the index, pass in the skip-add argument:
+```bash
+yo angular:service serviceName --skip-add
+```
+
 ## Bower Components
 
 The following packages are always installed by the [app](#app) generator:

--- a/script-base.js
+++ b/script-base.js
@@ -100,8 +100,10 @@ Generator.prototype.addScriptToIndex = function (script) {
   }
 };
 
-Generator.prototype.generateSourceAndTest = function (appTemplate, testTemplate, targetDirectory) {
+Generator.prototype.generateSourceAndTest = function (appTemplate, testTemplate, targetDirectory, skipAdd) {
   this.appTemplate(appTemplate, path.join('scripts', targetDirectory, this.name));
   this.testTemplate(testTemplate, path.join(targetDirectory, this.name));
-  this.addScriptToIndex(path.join(targetDirectory, this.name));
+  if (!skipAdd) {
+    this.addScriptToIndex(path.join(targetDirectory, this.name));
+  }
 };

--- a/service/index.js
+++ b/service/index.js
@@ -10,5 +10,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.generateSourceAndTest('service/service', 'spec/service', 'services');
+  this.generateSourceAndTest(
+    'service/service',
+    'spec/service',
+    'services',
+    this.options['skip-add'] || false
+  );
 };

--- a/value/index.js
+++ b/value/index.js
@@ -10,5 +10,10 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createServiceFiles = function createServiceFiles() {
-  this.generateSourceAndTest('service/value', 'spec/service', 'services');
+  this.generateSourceAndTest(
+    'service/value',
+    'spec/service',
+    'services',
+    this.options['skip-add'] || false
+  );
 };


### PR DESCRIPTION
Allow skipping of adding script to index file with default being to add.

Allows this to be used in angularjs generators that don't have an index file
