### PR TITLE
feat(gen): allow app names to have custom suffix

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
 var util = require('util');
+var angularUtils = require('../util.js');
 var spawn = require('child_process').spawn;
 var yeoman = require('yeoman-generator');
 
@@ -9,6 +10,14 @@ var Generator = module.exports = function Generator(args, options) {
   yeoman.generators.Base.apply(this, arguments);
   this.argument('appname', { type: String, required: false });
   this.appname = this.appname || path.basename(process.cwd());
+  this.appname = this._.camelize(this._.slugify(this._.humanize(this.appname)));
+
+  this.option('app-suffix', {
+    desc: 'Allow a custom suffix to be added to the module name',
+    type: String,
+    required: 'false'
+  });
+  this.scriptAppName = this.appname + angularUtils.appName(this);
 
   args = ['main'];
 

--- a/route/index.js
+++ b/route/index.js
@@ -23,7 +23,7 @@ Generator.prototype.rewriteAppJs = function () {
     needle: '.otherwise',
     splicable: [
       "  templateUrl: 'views/" + this.name + ".html'" + (coffee ? "" : "," ),
-      "  controller: '" + this._.classify(this.name) + "Ctrl'"
+      "  controller: '" + this.classedName + "Ctrl'"
     ]
   };
 

--- a/script-base.js
+++ b/script-base.js
@@ -12,6 +12,11 @@ var Generator = module.exports = function Generator() {
   } catch (e) {
     this.appname = path.basename(process.cwd());
   }
+  this.appname = this._.slugify(this._.humanize(this.appname));
+  this.scriptAppName = this._.camelize(this.appname) + angularUtils.appName(this);
+
+  this.cameledName = this._.camelize(this.name);
+  this.classedName = this._.classify(this.name);
 
   if (typeof this.env.options.appPath === 'undefined') {
     try {

--- a/templates/coffeescript-min/app.coffee
+++ b/templates/coffeescript-min/app.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App', [<%= angularModules %>])
+angular.module('<%= scriptAppName %>', [<%= angularModules %>])
   .config ['$routeProvider', ($routeProvider) ->
     $routeProvider
       .when '/',

--- a/templates/coffeescript-min/controller.coffee
+++ b/templates/coffeescript-min/controller.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .controller '<%= _.classify(name) %>Ctrl', ['$scope', ($scope) ->
+angular.module('<%= scriptAppName %>')
+  .controller '<%= classedName %>Ctrl', ['$scope', ($scope) ->
     $scope.awesomeThings = [
       'HTML5 Boilerplate'
       'AngularJS'

--- a/templates/coffeescript-min/decorator.coffee
+++ b/templates/coffeescript-min/decorator.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module("<%= _.camelize(appname) %>App").config ["$provide", ($provide) ->
-  $provide.decorator "<%= _.camelize(name) %>", ($delegate) ->
+angular.module("<%= scriptAppName").config ["$provide", ($provide) ->
+  $provide.decorator "<%= cameledName %>", ($delegate) ->
     # decorate the $delegate
     $delegate
 ]

--- a/templates/coffeescript-min/directive.coffee
+++ b/templates/coffeescript-min/directive.coffee
@@ -1,9 +1,9 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .directive '<%= _.camelize(name) %>', [->
+angular.module('<%= scriptAppName %>')
+  .directive '<%= cameledName %>', [->
     template: '<div></div>'
     restrict: 'E'
     link: (scope, element, attrs) ->
-      element.text 'this is the <%= _.camelize(name) %> directive'
+      element.text 'this is the <%= cameledName %> directive'
   ]

--- a/templates/coffeescript-min/filter.coffee
+++ b/templates/coffeescript-min/filter.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .filter '<%= _.camelize(name) %>', [() ->
+angular.module('<%= scriptAppName %>')
+  .filter '<%= cameledName %>', [() ->
     (input) ->
-      '<%= _.camelize(name) %> filter: ' + input
+      '<%= cameledName %> filter: ' + input
   ]

--- a/templates/coffeescript-min/service/constant.coffee
+++ b/templates/coffeescript-min/service/constant.coffee
@@ -1,4 +1,4 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .constant '<%= _.camelize(name) %>', 42
+angular.module('<%= scriptAppName %>')
+  .constant '<%= cameledName %>', 42

--- a/templates/coffeescript-min/service/factory.coffee
+++ b/templates/coffeescript-min/service/factory.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .factory '<%= _.camelize(name) %>', [() ->
+angular.module('<%= scriptAppName %>')
+  .factory '<%= cameledName %>', [() ->
     # Service logic
     # ...
 

--- a/templates/coffeescript-min/service/provider.coffee
+++ b/templates/coffeescript-min/service/provider.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .provider '<%= _.camelize(name) %>', [->
+angular.module('<%= scriptAppName %>')
+  .provider '<%= cameledName %>', [->
 
     # Private variables
     salutation = 'Hello'

--- a/templates/coffeescript-min/service/service.coffee
+++ b/templates/coffeescript-min/service/service.coffee
@@ -1,5 +1,5 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .service '<%= _.classify(name) %>', () ->
+angular.module('<%= scriptAppName %>')
+  .service '<%= classedName %>', () ->
     # AngularJS will instantiate a singleton by calling "new" on this function

--- a/templates/coffeescript-min/service/value.coffee
+++ b/templates/coffeescript-min/service/value.coffee
@@ -1,4 +1,4 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .value '<%= _.camelize(name) %>', 42
+angular.module('<%= scriptAppName %>')
+  .value '<%= cameledName %>', 42

--- a/templates/coffeescript-min/spec/controller.coffee
+++ b/templates/coffeescript-min/spec/controller.coffee
@@ -1,17 +1,17 @@
 'use strict'
 
-describe 'Controller: <%= _.classify(name) %>Ctrl', () ->
+describe 'Controller: <%= classedName %>Ctrl', () ->
 
   # load the controller's module
-  beforeEach module '<%= _.camelize(appname) %>App'
+  beforeEach module '<%= scriptAppName %>'
 
-  <%= _.classify(name) %>Ctrl = {}
+  <%= classedName %>Ctrl = {}
   scope = {}
 
   # Initialize the controller and a mock scope
   beforeEach inject ($controller, $rootScope) ->
     scope = $rootScope.$new()
-    <%= _.classify(name) %>Ctrl = $controller '<%= _.classify(name) %>Ctrl', {
+    <%= classedName %>Ctrl = $controller '<%= classedName %>Ctrl', {
       $scope: scope
     }
 

--- a/templates/coffeescript-min/spec/directive.coffee
+++ b/templates/coffeescript-min/spec/directive.coffee
@@ -1,9 +1,9 @@
 'use strict'
 
-describe 'Directive: <%= _.camelize(name) %>', () ->
+describe 'Directive: <%= cameledName %>', () ->
 
   # load the directive's module
-  beforeEach module '<%= _.camelize(appname) %>App'
+  beforeEach module '<%= scriptAppName %>'
 
   scope = {}
 
@@ -13,4 +13,4 @@ describe 'Directive: <%= _.camelize(name) %>', () ->
   it 'should make hidden element visible', inject ($compile) ->
     element = angular.element '<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>'
     element = $compile(element) scope
-    expect(element.text()).toBe 'this is the <%= _.camelize(name) %> directive'
+    expect(element.text()).toBe 'this is the <%= cameledName %> directive'

--- a/templates/coffeescript-min/spec/filter.coffee
+++ b/templates/coffeescript-min/spec/filter.coffee
@@ -1,15 +1,15 @@
 'use strict'
 
-describe 'Filter: <%= _.camelize(name) %>', () ->
+describe 'Filter: <%= cameledName %>', () ->
 
   # load the filter's module
-  beforeEach module '<%= _.camelize(appname) %>App'
+  beforeEach module '<%= scriptAppName %>'
 
   # initialize a new instance of the filter before each test
-  <%= _.camelize(name) %> = {}
+  <%= cameledName %> = {}
   beforeEach inject ($filter) ->
-    <%= _.camelize(name) %> = $filter '<%= _.camelize(name) %>'
+    <%= cameledName %> = $filter '<%= cameledName %>'
 
-  it 'should return the input prefixed with "<%= _.camelize(name) %> filter:"', () ->
+  it 'should return the input prefixed with "<%= cameledName %> filter:"', () ->
     text = 'angularjs'
-    expect(<%= _.camelize(name) %> text).toBe ('<%= _.camelize(name) %> filter: ' + text)
+    expect(<%= cameledName %> text).toBe ('<%= cameledName %> filter: ' + text)

--- a/templates/coffeescript-min/spec/service.coffee
+++ b/templates/coffeescript-min/spec/service.coffee
@@ -1,14 +1,14 @@
 'use strict'
 
-describe 'Service: <%= _.classify(name) %>', () ->
+describe 'Service: <%= classedName %>', () ->
 
   # load the service's module
-  beforeEach module '<%= _.classify(appname) %>App'
+  beforeEach module '<%= scriptAppName %>App'
 
   # instantiate service
-  <%= _.classify(name) %> = {}
-  beforeEach inject (_<%= _.classify(name) %>_) ->
-    <%= _.classify(name) %> = _<%= _.classify(name) %>_
+  <%= classedName %> = {}
+  beforeEach inject (_<%= classedName %>_) ->
+    <%= classedName %> = _<%= classedName %>_
 
   it 'should do something', () ->
-    expect(!!<%= _.classify(name) %>).toBe true
+    expect(!!<%= classedName %>).toBe true

--- a/templates/coffeescript/app.coffee
+++ b/templates/coffeescript/app.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App', [<%= angularModules %>])
+angular.module('<%= scriptAppName %>', [<%= angularModules %>])
   .config ($routeProvider) ->
     $routeProvider
       .when '/',

--- a/templates/coffeescript/controller.coffee
+++ b/templates/coffeescript/controller.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .controller '<%= _.classify(name) %>Ctrl', ($scope) ->
+angular.module('<%= scriptAppName %>')
+  .controller '<%= classedName %>Ctrl', ($scope) ->
     $scope.awesomeThings = [
       'HTML5 Boilerplate'
       'AngularJS'

--- a/templates/coffeescript/decorator.coffee
+++ b/templates/coffeescript/decorator.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module("<%= _.camelize(appname) %>App").config ($provide) ->
-  $provide.decorator "<%= _.camelize(name) %>", ($delegate) ->
+angular.module("<%= scriptAppName").config ($provide) ->
+  $provide.decorator "<%= cameledName %>", ($delegate) ->
     # decorate the $delegate
     $delegate

--- a/templates/coffeescript/directive.coffee
+++ b/templates/coffeescript/directive.coffee
@@ -1,9 +1,9 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .directive('<%= _.camelize(name) %>', () ->
+angular.module('<%= scriptAppName %>')
+  .directive('<%= cameledName %>', () ->
     template: '<div></div>'
     restrict: 'E'
     link: (scope, element, attrs) ->
-      element.text 'this is the <%= _.camelize(name) %> directive'
+      element.text 'this is the <%= cameledName %> directive'
   )

--- a/templates/coffeescript/filter.coffee
+++ b/templates/coffeescript/filter.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .filter '<%= _.camelize(name) %>', () ->
+angular.module('<%= scriptAppName %>')
+  .filter '<%= cameledName %>', () ->
     (input) ->
-      '<%= _.camelize(name) %> filter: ' + input
+      '<%= cameledName %> filter: ' + input

--- a/templates/coffeescript/service/constant.coffee
+++ b/templates/coffeescript/service/constant.coffee
@@ -1,4 +1,4 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .constant '<%= _.camelize(name) %>', 42
+angular.module('<%= scriptAppName %>')
+  .constant '<%= cameledName %>', 42

--- a/templates/coffeescript/service/factory.coffee
+++ b/templates/coffeescript/service/factory.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .factory '<%= _.camelize(name) %>', () ->
+angular.module('<%= scriptAppName %>')
+  .factory '<%= cameledName %>', () ->
     # Service logic
     # ...
 

--- a/templates/coffeescript/service/provider.coffee
+++ b/templates/coffeescript/service/provider.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .provider '<%= _.camelize(name) %>', [->
+angular.module('<%= scriptAppName %>')
+  .provider '<%= cameledName %>', [->
 
     # Private variables
     salutation = 'Hello'

--- a/templates/coffeescript/service/service.coffee
+++ b/templates/coffeescript/service/service.coffee
@@ -1,5 +1,5 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .service '<%= _.classify(name) %>', () ->
+angular.module('<%= scriptAppName %>')
+  .service '<%= classedName %>', () ->
     # AngularJS will instantiate a singleton by calling "new" on this function

--- a/templates/coffeescript/service/value.coffee
+++ b/templates/coffeescript/service/value.coffee
@@ -1,4 +1,4 @@
 'use strict'
 
-angular.module('<%= _.camelize(appname) %>App')
-  .value '<%= _.camelize(name) %>', 42
+angular.module('<%= scriptAppName %>')
+  .value '<%= cameledName %>', 42

--- a/templates/coffeescript/spec/controller.coffee
+++ b/templates/coffeescript/spec/controller.coffee
@@ -1,17 +1,17 @@
 'use strict'
 
-describe 'Controller: <%= _.classify(name) %>Ctrl', () ->
+describe 'Controller: <%= classedName %>Ctrl', () ->
 
   # load the controller's module
-  beforeEach module '<%= _.camelize(appname) %>App'
+  beforeEach module '<%= scriptAppName %>'
 
-  <%= _.classify(name) %>Ctrl = {}
+  <%= classedName %>Ctrl = {}
   scope = {}
 
   # Initialize the controller and a mock scope
   beforeEach inject ($controller, $rootScope) ->
     scope = $rootScope.$new()
-    <%= _.classify(name) %>Ctrl = $controller '<%= _.classify(name) %>Ctrl', {
+    <%= classedName %>Ctrl = $controller '<%= classedName %>Ctrl', {
       $scope: scope
     }
 

--- a/templates/coffeescript/spec/directive.coffee
+++ b/templates/coffeescript/spec/directive.coffee
@@ -1,9 +1,9 @@
 'use strict'
 
-describe 'Directive: <%= _.camelize(name) %>', () ->
+describe 'Directive: <%= cameledName %>', () ->
 
   # load the directive's module
-  beforeEach module '<%= _.camelize(appname) %>App'
+  beforeEach module '<%= scriptAppName %>'
 
   scope = {}
 
@@ -13,4 +13,4 @@ describe 'Directive: <%= _.camelize(name) %>', () ->
   it 'should make hidden element visible', inject ($compile) ->
     element = angular.element '<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>'
     element = $compile(element) scope
-    expect(element.text()).toBe 'this is the <%= _.camelize(name) %> directive'
+    expect(element.text()).toBe 'this is the <%= cameledName %> directive'

--- a/templates/coffeescript/spec/filter.coffee
+++ b/templates/coffeescript/spec/filter.coffee
@@ -1,15 +1,15 @@
 'use strict'
 
-describe 'Filter: <%= _.camelize(name) %>', () ->
+describe 'Filter: <%= cameledName %>', () ->
 
   # load the filter's module
-  beforeEach module '<%= _.camelize(appname) %>App'
+  beforeEach module '<%= scriptAppName %>'
 
   # initialize a new instance of the filter before each test
-  <%= _.camelize(name) %> = {}
+  <%= cameledName %> = {}
   beforeEach inject ($filter) ->
-    <%= _.camelize(name) %> = $filter '<%= _.camelize(name) %>'
+    <%= cameledName %> = $filter '<%= cameledName %>'
 
-  it 'should return the input prefixed with "<%= _.camelize(name) %> filter:"', () ->
+  it 'should return the input prefixed with "<%= cameledName %> filter:"', () ->
     text = 'angularjs'
-    expect(<%= _.camelize(name) %> text).toBe ('<%= _.camelize(name) %> filter: ' + text)
+    expect(<%= cameledName %> text).toBe ('<%= cameledName %> filter: ' + text)

--- a/templates/coffeescript/spec/service.coffee
+++ b/templates/coffeescript/spec/service.coffee
@@ -1,14 +1,14 @@
 'use strict'
 
-describe 'Service: <%= _.classify(name) %>', () ->
+describe 'Service: <%= classedName %>', () ->
 
   # load the service's module
-  beforeEach module '<%= _.classify(appname) %>App'
+  beforeEach module '<%= scriptAppName %>App'
 
   # instantiate service
-  <%= _.classify(name) %> = {}
-  beforeEach inject (_<%= _.classify(name) %>_) ->
-    <%= _.classify(name) %> = _<%= _.classify(name) %>_
+  <%= classedName %> = {}
+  beforeEach inject (_<%= classedName %>_) ->
+    <%= classedName %> = _<%= classedName %>_
 
   it 'should do something', () ->
-    expect(!!<%= _.classify(name) %>).toBe true
+    expect(!!<%= classedName %>).toBe true

--- a/templates/common/_bower.json
+++ b/templates/common/_bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= _.camelize(appname) %>",
+  "name": "<%= _.slugify(_.humanize(appname)) %>",
   "version": "0.0.0",
   "dependencies": {
     "angular": "~1.0.7",

--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
   </head>
-  <body ng-app="<%= _.camelize(appname) %>App">
+  <body ng-app="<%= scriptAppName %>">
     <!--[if lt IE 7]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->

--- a/templates/javascript-min/app.js
+++ b/templates/javascript-min/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App', [<%= angularModules %>])
+angular.module('<%= scriptAppName %>', [<%= angularModules %>])
   .config(['$routeProvider', function ($routeProvider) {
     $routeProvider
       .when('/', {

--- a/templates/javascript-min/controller.js
+++ b/templates/javascript-min/controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .controller('<%= _.classify(name) %>Ctrl', ['$scope', function ($scope) {
+angular.module('<%= scriptAppName %>')
+  .controller('<%= classedName %>Ctrl', ['$scope', function ($scope) {
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',

--- a/templates/javascript-min/decorator.js
+++ b/templates/javascript-min/decorator.js
@@ -1,8 +1,8 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
+angular.module('<%= scriptAppName %>')
     .config(['$provide', function ($provide) {
-        $provide.decorator('<%= _.camelize(name) %>', function ($delegate) {
+        $provide.decorator('<%= cameledName %>', function ($delegate) {
             // decorate the $delegate
             return $delegate;
         });

--- a/templates/javascript-min/directive.js
+++ b/templates/javascript-min/directive.js
@@ -1,12 +1,12 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .directive('<%= _.camelize(name) %>', [function () {
+angular.module('<%= scriptAppName %>')
+  .directive('<%= cameledName %>', [function () {
     return {
       template: '<div></div>',
       restrict: 'E',
       link: function postLink(scope, element, attrs) {
-        element.text('this is the <%= _.camelize(name) %> directive');
+        element.text('this is the <%= cameledName %> directive');
       }
     };
   }]);

--- a/templates/javascript-min/filter.js
+++ b/templates/javascript-min/filter.js
@@ -1,8 +1,8 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .filter('<%= _.camelize(name) %>', [function () {
+angular.module('<%= scriptAppName %>')
+  .filter('<%= cameledName %>', [function () {
     return function (input) {
-      return '<%= _.camelize(name) %> filter: ' + input;
+      return '<%= cameledName %> filter: ' + input;
     };
   }]);

--- a/templates/javascript-min/service/constant.js
+++ b/templates/javascript-min/service/constant.js
@@ -1,4 +1,4 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .constant('<%= _.camelize(name) %>', 42);
+angular.module('<%= scriptAppName %>')
+  .constant('<%= cameledName %>', 42);

--- a/templates/javascript-min/service/factory.js
+++ b/templates/javascript-min/service/factory.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .factory('<%= _.camelize(name) %>', [function() {
+angular.module('<%= scriptAppName %>')
+  .factory('<%= cameledName %>', [function() {
     // Service logic
     // ...
 

--- a/templates/javascript-min/service/provider.js
+++ b/templates/javascript-min/service/provider.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .provider('<%= _.camelize(name) %>', [function() {
+angular.module('<%= scriptAppName %>')
+  .provider('<%= cameledName %>', [function() {
 
     // Private variables
     var salutation = 'Hello';

--- a/templates/javascript-min/service/service.js
+++ b/templates/javascript-min/service/service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .service('<%= _.classify(name) %>', function <%= _.classify(name) %>() {
+angular.module('<%= scriptAppName %>')
+  .service('<%= classedName %>', function <%= classedName %>() {
     // AngularJS will instantiate a singleton by calling "new" on this function
   });

--- a/templates/javascript-min/service/value.js
+++ b/templates/javascript-min/service/value.js
@@ -1,4 +1,4 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .value('<%= _.camelize(name) %>', 42);
+angular.module('<%= scriptAppName %>')
+  .value('<%= cameledName %>', 42);

--- a/templates/javascript-min/spec/controller.js
+++ b/templates/javascript-min/spec/controller.js
@@ -1,17 +1,17 @@
 'use strict';
 
-describe('Controller: <%= _.classify(name) %>Ctrl', function () {
+describe('Controller: <%= classedName %>Ctrl', function () {
 
   // load the controller's module
-  beforeEach(module('<%= _.camelize(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
-  var <%= _.classify(name) %>Ctrl,
+  var <%= classedName %>Ctrl,
     scope;
 
   // Initialize the controller and a mock scope
   beforeEach(inject(function ($controller, $rootScope) {
     scope = $rootScope.$new();
-    <%= _.classify(name) %>Ctrl = $controller('<%= _.classify(name) %>Ctrl', {
+    <%= classedName %>Ctrl = $controller('<%= classedName %>Ctrl', {
       $scope: scope
     });
   }));

--- a/templates/javascript-min/spec/directive.js
+++ b/templates/javascript-min/spec/directive.js
@@ -1,9 +1,9 @@
 'use strict';
 
-describe('Directive: <%= _.camelize(name) %>', function () {
+describe('Directive: <%= cameledName %>', function () {
 
   // load the directive's module
-  beforeEach(module('<%= _.camelize(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
   var element,
     scope;
@@ -15,6 +15,6 @@ describe('Directive: <%= _.camelize(name) %>', function () {
   it('should make hidden element visible', inject(function ($compile) {
     element = angular.element('<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>');
     element = $compile(element)(scope);
-    expect(element.text()).toBe('this is the <%= _.camelize(name) %> directive');
+    expect(element.text()).toBe('this is the <%= cameledName %> directive');
   }));
 });

--- a/templates/javascript-min/spec/filter.js
+++ b/templates/javascript-min/spec/filter.js
@@ -1,19 +1,19 @@
 'use strict';
 
-describe('Filter: <%= _.camelize(name) %>', function () {
+describe('Filter: <%= cameledName %>', function () {
 
   // load the filter's module
-  beforeEach(module('<%= _.camelize(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
   // initialize a new instance of the filter before each test
-  var <%= _.camelize(name) %>;
+  var <%= cameledName %>;
   beforeEach(inject(function($filter) {
-    <%= _.camelize(name) %> = $filter('<%= _.camelize(name) %>');
+    <%= cameledName %> = $filter('<%= cameledName %>');
   }));
 
-  it('should return the input prefixed with "<%= _.camelize(name) %> filter:"', function () {
+  it('should return the input prefixed with "<%= cameledName %> filter:"', function () {
     var text = 'angularjs';
-    expect(<%= _.camelize(name) %>(text)).toBe('<%= _.camelize(name) %> filter: ' + text);
+    expect(<%= cameledName %>(text)).toBe('<%= cameledName %> filter: ' + text);
   });
 
 });

--- a/templates/javascript-min/spec/service.js
+++ b/templates/javascript-min/spec/service.js
@@ -1,18 +1,18 @@
 'use strict';
 
-describe('Service: <%= _.classify(name) %>', function () {
+describe('Service: <%= classedName %>', function () {
 
   // load the service's module
-  beforeEach(module('<%= _.classify(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>App'));
 
   // instantiate service
-  var <%= _.classify(name) %>;
-  beforeEach(inject(function(_<%= _.classify(name) %>_) {
-    <%= _.classify(name) %> = _<%= _.classify(name) %>_;
+  var <%= classedName %>;
+  beforeEach(inject(function(_<%= classedName %>_) {
+    <%= classedName %> = _<%= classedName %>_;
   }));
 
   it('should do something', function () {
-    expect(!!<%= _.classify(name) %>).toBe(true);
+    expect(!!<%= classedName %>).toBe(true);
   });
 
 });

--- a/templates/javascript/app.js
+++ b/templates/javascript/app.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App', [<%= angularModules %>])
+angular.module('<%= scriptAppName %>', [<%= angularModules %>])
   .config(function ($routeProvider) {
     $routeProvider
       .when('/', {

--- a/templates/javascript/controller.js
+++ b/templates/javascript/controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .controller('<%= _.classify(name) %>Ctrl', function ($scope) {
+angular.module('<%= scriptAppName %>')
+  .controller('<%= classedName %>Ctrl', function ($scope) {
     $scope.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',

--- a/templates/javascript/decorator.js
+++ b/templates/javascript/decorator.js
@@ -1,8 +1,8 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
+angular.module('<%= scriptAppName %>')
     .config(function ($provide) {
-        $provide.decorator('<%= _.camelize(name) %>', function ($delegate) {
+        $provide.decorator('<%= cameledName %>', function ($delegate) {
             // decorate the $delegate
             return $delegate;
         });

--- a/templates/javascript/directive.js
+++ b/templates/javascript/directive.js
@@ -1,12 +1,12 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .directive('<%= _.camelize(name) %>', function () {
+angular.module('<%= scriptAppName %>')
+  .directive('<%= cameledName %>', function () {
     return {
       template: '<div></div>',
       restrict: 'E',
       link: function postLink(scope, element, attrs) {
-        element.text('this is the <%= _.camelize(name) %> directive');
+        element.text('this is the <%= cameledName %> directive');
       }
     };
   });

--- a/templates/javascript/filter.js
+++ b/templates/javascript/filter.js
@@ -1,8 +1,8 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .filter('<%= _.camelize(name) %>', function () {
+angular.module('<%= scriptAppName %>')
+  .filter('<%= cameledName %>', function () {
     return function (input) {
-      return '<%= _.camelize(name) %> filter: ' + input;
+      return '<%= cameledName %> filter: ' + input;
     };
   });

--- a/templates/javascript/service/constant.js
+++ b/templates/javascript/service/constant.js
@@ -1,4 +1,4 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .constant('<%= _.camelize(name) %>', 42);
+angular.module('<%= scriptAppName %>')
+  .constant('<%= cameledName %>', 42);

--- a/templates/javascript/service/factory.js
+++ b/templates/javascript/service/factory.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .factory('<%= _.camelize(name) %>', function () {
+angular.module('<%= scriptAppName %>')
+  .factory('<%= cameledName %>', function () {
     // Service logic
     // ...
 

--- a/templates/javascript/service/provider.js
+++ b/templates/javascript/service/provider.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .provider('<%= _.camelize(name) %>', function () {
+angular.module('<%= scriptAppName %>')
+  .provider('<%= cameledName %>', function () {
 
     // Private variables
     var salutation = 'Hello';

--- a/templates/javascript/service/service.js
+++ b/templates/javascript/service/service.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .service('<%= _.classify(name) %>', function <%= _.classify(name) %>() {
+angular.module('<%= scriptAppName %>')
+  .service('<%= classedName %>', function <%= classedName %>() {
     // AngularJS will instantiate a singleton by calling "new" on this function
   });

--- a/templates/javascript/service/value.js
+++ b/templates/javascript/service/value.js
@@ -1,4 +1,4 @@
 'use strict';
 
-angular.module('<%= _.camelize(appname) %>App')
-  .value('<%= _.camelize(name) %>', 42);
+angular.module('<%= scriptAppName %>')
+  .value('<%= cameledName %>', 42);

--- a/templates/javascript/spec/controller.js
+++ b/templates/javascript/spec/controller.js
@@ -1,17 +1,17 @@
 'use strict';
 
-describe('Controller: <%= _.classify(name) %>Ctrl', function () {
+describe('Controller: <%= classedName %>Ctrl', function () {
 
   // load the controller's module
-  beforeEach(module('<%= _.camelize(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
-  var <%= _.classify(name) %>Ctrl,
+  var <%= classedName %>Ctrl,
     scope;
 
   // Initialize the controller and a mock scope
   beforeEach(inject(function ($controller, $rootScope) {
     scope = $rootScope.$new();
-    <%= _.classify(name) %>Ctrl = $controller('<%= _.classify(name) %>Ctrl', {
+    <%= classedName %>Ctrl = $controller('<%= classedName %>Ctrl', {
       $scope: scope
     });
   }));

--- a/templates/javascript/spec/directive.js
+++ b/templates/javascript/spec/directive.js
@@ -1,9 +1,9 @@
 'use strict';
 
-describe('Directive: <%= _.camelize(name) %>', function () {
+describe('Directive: <%= cameledName %>', function () {
 
   // load the directive's module
-  beforeEach(module('<%= _.camelize(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
   var element,
     scope;
@@ -15,6 +15,6 @@ describe('Directive: <%= _.camelize(name) %>', function () {
   it('should make hidden element visible', inject(function ($compile) {
     element = angular.element('<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>');
     element = $compile(element)(scope);
-    expect(element.text()).toBe('this is the <%= _.camelize(name) %> directive');
+    expect(element.text()).toBe('this is the <%= cameledName %> directive');
   }));
 });

--- a/templates/javascript/spec/filter.js
+++ b/templates/javascript/spec/filter.js
@@ -1,19 +1,19 @@
 'use strict';
 
-describe('Filter: <%= _.camelize(name) %>', function () {
+describe('Filter: <%= cameledName %>', function () {
 
   // load the filter's module
-  beforeEach(module('<%= _.camelize(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
   // initialize a new instance of the filter before each test
-  var <%= _.camelize(name) %>;
+  var <%= cameledName %>;
   beforeEach(inject(function ($filter) {
-    <%= _.camelize(name) %> = $filter('<%= _.camelize(name) %>');
+    <%= cameledName %> = $filter('<%= cameledName %>');
   }));
 
-  it('should return the input prefixed with "<%= _.camelize(name) %> filter:"', function () {
+  it('should return the input prefixed with "<%= cameledName %> filter:"', function () {
     var text = 'angularjs';
-    expect(<%= _.camelize(name) %>(text)).toBe('<%= _.camelize(name) %> filter: ' + text);
+    expect(<%= cameledName %>(text)).toBe('<%= cameledName %> filter: ' + text);
   });
 
 });

--- a/templates/javascript/spec/service.js
+++ b/templates/javascript/spec/service.js
@@ -1,18 +1,18 @@
 'use strict';
 
-describe('Service: <%= _.classify(name) %>', function () {
+describe('Service: <%= classedName %>', function () {
 
   // load the service's module
-  beforeEach(module('<%= _.classify(appname) %>App'));
+  beforeEach(module('<%= scriptAppName %>App'));
 
   // instantiate service
-  var <%= _.classify(name) %>;
-  beforeEach(inject(function (_<%= _.classify(name) %>_) {
-    <%= _.classify(name) %> = _<%= _.classify(name) %>_;
+  var <%= classedName %>;
+  beforeEach(inject(function (_<%= classedName %>_) {
+    <%= classedName %> = _<%= classedName %>_;
   }));
 
   it('should do something', function () {
-    expect(!!<%= _.classify(name) %>).toBe(true);
+    expect(!!<%= classedName %>).toBe(true);
   });
 
 });

--- a/test/test-appname-substitution.js
+++ b/test/test-appname-substitution.js
@@ -34,7 +34,7 @@ describe('Angular generator template mechanism', function () {
     });
 
     it('should generate the same appName in every file', function (done) {
-        var expectedAppName = folderName + 'App';
+        var expectedAppName = 'upperCaseBugApp';
         var expected = [
             'app/scripts/app.js',
             'app/scripts/controllers/main.js',

--- a/util.js
+++ b/util.js
@@ -5,7 +5,8 @@ var fs = require('fs');
 
 module.exports = {
   rewrite: rewrite,
-  rewriteFile: rewriteFile
+  rewriteFile: rewriteFile,
+  appName: appName
 };
 
 function rewriteFile (args) {
@@ -56,4 +57,18 @@ function rewrite (args) {
   }).join('\n'));
 
   return lines.join('\n');
+}
+
+function appName (self) {
+  var counter = 0, suffix = self.options['app-suffix'];
+  // Have to check this because of generator bug #386
+  process.argv.forEach(function(val) {
+    if (val.indexOf('--app-suffix') > -1) {
+      counter++;
+    }
+  });
+  if (counter === 0 || (typeof suffix === 'boolean' && suffix)) {
+    suffix = 'App';
+  }
+  return suffix ? self._.classify(suffix) : '';
 }


### PR DESCRIPTION
Allow app names to have a custom suffix with app-suffix option. By
default, it uses 'App'

Breaks existing app names that began with a capital letter
