### PR TITLE
Always use random port number for livereload

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -11,6 +11,15 @@ module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt);
   require('time-grunt')(grunt);
 
+  function getRandomPortForLiveReload() {
+    var server = require('net').createServer();
+    var port = server.listen(0).address().port;
+
+    server.close();
+
+    return port;
+  }
+
   grunt.initConfig({
     yeoman: {
       // configurable paths
@@ -62,7 +71,7 @@ module.exports = function (grunt) {
         port: 9000,
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
-        livereload: 35729
+        livereload: getRandomPortForLiveReload()
       },
       livereload: {
         options: {


### PR DESCRIPTION
If you have more than 1 application generated by yeoman, they all share the same livereload port that makes it difficult to run them simultaneously without modifying Gruntfile. Listening on zero-port is a pretty common solution to ask OS for a random port number and it's cross-platform as well. Let's make user's life easier!
