### PR TITLE
Update angular version to 1.2.0

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -68,7 +68,7 @@ var Generator = module.exports = function Generator(args, options) {
   this.on('end', function () {
     this.installDependencies({ skipInstall: this.options['skip-install'] });
 
-    var enabledComponents = [];
+    var enabledComponents = ['angular-route/angular-route.js'];
 
     if (this.resourceModule) {
       enabledComponents.push('angular-resource/angular-resource.js');
@@ -152,7 +152,7 @@ Generator.prototype.askForModules = function askForModules() {
     this.cookiesModule = hasMod('cookiesModule');
     this.sanitizeModule = hasMod('sanitizeModule');
 
-    var angMods = [];
+    var angMods = ["'ngRoute'"];
 
     if (this.cookiesModule) {
       angMods.push("'ngCookies'");
@@ -231,7 +231,7 @@ Generator.prototype.bootstrapJS = function bootstrapJS() {
 };
 
 Generator.prototype.extraModules = function extraModules() {
-  var modules = [];
+  var modules = ['bower_components/angular-route/angular-route.js'];
   if (this.resourceModule) {
     modules.push('bower_components/angular-resource/angular-resource.js');
   }

--- a/templates/common/_bower.json
+++ b/templates/common/_bower.json
@@ -2,17 +2,18 @@
   "name": "<%= _.slugify(_.humanize(appname)) %>",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "~1.0.8",
+    "angular": "~1.2.0",
+    "angular-route": "~1.2.0",
     "json3": "~3.2.4",<% if (bootstrap) { %>
     "jquery": "~1.10.0",
     "sass-bootstrap": "~3.0.0",
     <% } %>"es5-shim": "~2.0.8"<% if (resourceModule) { %>,
-    "angular-resource": "~1.0.7"<% } %><% if (cookiesModule) { %>,
-    "angular-cookies": "~1.0.7"<% } %><% if (sanitizeModule) { %>,
-    "angular-sanitize": "~1.0.7"<% } %>
+    "angular-resource": "~1.2.0"<% } %><% if (cookiesModule) { %>,
+    "angular-cookies": "~1.2.0"<% } %><% if (sanitizeModule) { %>,
+    "angular-sanitize": "~1.2.0"<% } %>
   },
   "devDependencies": {
-    "angular-mocks": "~1.0.7",
-    "angular-scenario": "~1.0.7"
+    "angular-mocks": "~1.2.0",
+    "angular-scenario": "~1.2.0"
   }
 }


### PR DESCRIPTION
Discussed in #405
AngularJS 1.2.0 is stable as of [today](http://blog.angularjs.org/2013/11/angularjs-120-timely-delivery.html).

Major changes:
- `ngRoute` is a separate module which is required by the app. For that reason I included it by default.

I've been considering on adding angular-animate as an option in the prompt. Thoughs on this?
