### PR TITLE
fix(gen): remove extra "App" from service spec files

### DIFF
--- a/templates/coffeescript-min/spec/service.coffee
+++ b/templates/coffeescript-min/spec/service.coffee
@@ -3,7 +3,7 @@
 describe 'Service: <%= classedName %>', () ->
 
   # load the service's module
-  beforeEach module '<%= scriptAppName %>App'
+  beforeEach module '<%= scriptAppName %>'
 
   # instantiate service
   <%= classedName %> = {}

--- a/templates/coffeescript/spec/service.coffee
+++ b/templates/coffeescript/spec/service.coffee
@@ -3,7 +3,7 @@
 describe 'Service: <%= classedName %>', () ->
 
   # load the service's module
-  beforeEach module '<%= scriptAppName %>App'
+  beforeEach module '<%= scriptAppName %>'
 
   # instantiate service
   <%= classedName %> = {}

--- a/templates/javascript-min/spec/service.js
+++ b/templates/javascript-min/spec/service.js
@@ -3,7 +3,7 @@
 describe('Service: <%= classedName %>', function () {
 
   // load the service's module
-  beforeEach(module('<%= scriptAppName %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
   // instantiate service
   var <%= classedName %>;

--- a/templates/javascript/spec/service.js
+++ b/templates/javascript/spec/service.js
@@ -3,7 +3,7 @@
 describe('Service: <%= classedName %>', function () {
 
   // load the service's module
-  beforeEach(module('<%= scriptAppName %>App'));
+  beforeEach(module('<%= scriptAppName %>'));
 
   // instantiate service
   var <%= classedName %>;


### PR DESCRIPTION
#413 missed an extra 'App' when loading the app module in all the service spec files that made the tests fail. The other spec files are correct.
