### PR TITLE
Fixed Grunt watch targets to properly include subdirectories

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -19,19 +19,19 @@ module.exports = function (grunt) {
     },
     watch: {
       coffee: {
-        files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
+        files: ['<%%= yeoman.app %>/scripts/{,**/}*.coffee'],
         tasks: ['coffee:dist']
       },
       coffeeTest: {
-        files: ['test/spec/{,*/}*.coffee'],
+        files: ['test/spec/{,**/}*.coffee'],
         tasks: ['coffee:test']
       },<% if (compassBootstrap) { %>
       compass: {
-        files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+        files: ['<%%= yeoman.app %>/styles/{,**/}*.{scss,sass}'],
         tasks: ['compass:server', 'autoprefixer']
       },<% } %>
       styles: {
-        files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
+        files: ['<%%= yeoman.app %>/styles/{,**/}*.css'],
         tasks: ['copy:styles', 'autoprefixer']
       },
       gruntfile: {
@@ -42,10 +42,10 @@ module.exports = function (grunt) {
           livereload: '<%%= connect.options.livereload %>'
         },
         files: [
-          '<%%= yeoman.app %>/{,*/}*.html',
-          '.tmp/styles/{,*/}*.css',
-          '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
-          '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+          '<%%= yeoman.app %>/{,**/}*.html',
+          '.tmp/styles/{,**/}*.css',
+          '{.tmp,<%%= yeoman.app %>}/scripts/{,**/}*.js',
+          '<%%= yeoman.app %>/images/{,**/}*.{png,jpg,jpeg,gif,webp,svg}'
         ]
       }
     },


### PR DESCRIPTION
The previous watch target patterns were of the form,  
   "pathX/{,_/}_.suf", 
but should be 
   "pathX/{,**/}_.suf" 
to properly imply 
   "pathX/_.suf" for top level and 
   "pathX/**/*.suf" for subdirectory search.

There are other areas that require this treatment, but I am too new to grunt, yeoman, et al to risk any further changes. I leave it to my betters :)
