### PR TITLE
Fix Windows broken paths

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -97,7 +97,7 @@ Generator.prototype.addScriptToIndex = function (script) {
       file: fullPath,
       needle: '<!-- endbuild -->',
       splicable: [
-        '<script src="scripts/' + script + '.js"></script>'
+        '<script src="scripts/' + script.replace('\\', '/') + '.js"></script>'
       ]
     });
   } catch (e) {


### PR DESCRIPTION
Using path.join creates backslashes. Script src uses forward slashes

Fixes #410
