### PR TITLE
feat(build): deprecate server in favor of serve

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@ Run `yo angular`, optionally passing an app name:
 yo angular [app-name]
 ```
 
+Run `grunt` for building and `grunt serve` for preview
+
+
 ## Generators
 
 Available generators:

--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -327,7 +327,7 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('server', function (target) {
+  grunt.registerTask('serve', function (target) {
     if (target === 'dist') {
       return grunt.task.run(['build', 'connect:dist:keepalive']);
     }
@@ -339,6 +339,11 @@ module.exports = function (grunt) {
       'connect:livereload',
       'watch'
     ]);
+  });
+
+  grunt.registerTask('server', function () {
+    grunt.log.warn('The `server` task has been deprecated. Use `grunt serve` to start a server.');
+    grunt.task.run(['serve']);
   });
 
   grunt.registerTask('test', [


### PR DESCRIPTION
Use `grunt serve` instead of server per webapps upstream change

References #35
BREAKING CHANGE: `grunt server` is being deprecated
