### PR TITLE
feature(index.html): support for bower installed css files during minification

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -216,7 +216,7 @@ Generator.prototype.bootstrapFiles = function bootstrapFiles() {
     sourceFileList: files.map(function (file) {
       return 'styles/' + file.replace('.scss', '.css');
     }),
-    searchPath: '.tmp'
+    searchPath: ['.tmp', 'app']
   });
 };
 


### PR DESCRIPTION
solve missing .css files during grunt:build minification due to files being installed via bower (and not copied with grunt:copy:styles)
