### PR TITLE
fix(build): use test-specifc jshintrc

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -105,9 +105,14 @@ module.exports = function (grunt) {
       },
       all: [
         'Gruntfile.js'<% if (!coffee) { %>,
-        '<%%= yeoman.app %>/scripts/{,*/}*.js',
-        'test/spec/{,*/}*.js'<% } %>
-      ]
+        '<%%= yeoman.app %>/scripts/{,*/}*.js'<% } %>
+      ]<% if (!coffee) { %>,
+      test: {
+        options: {
+          jshintrc: 'test/.jshintrc'
+        },
+        src: ['test/spec/{,*/}*.js']
+      }<% } %>
     },
 
     // Empties folders to start fresh


### PR DESCRIPTION
Running `grunt` on the current master doesn't work for me at the moment and fail with undefined `beforeEach`, `it` ... globals. I don't whether it a change on our side or on grunt-contrib-jshint's that introduced this. 

@eddiemonge Do you have an idea and does this lgty?
