### PR TITLE
feat(gen): add base tag support for index.html

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -377,6 +377,18 @@ module.exports = function (grunt) {
         configFile: 'karma.conf.js',
         singleRun: true
       }
+    },
+    targethtml: {
+      dist: {
+        options: {
+          curlyTags: {
+            base: '/'
+          }
+        },
+        files: {
+          '<%%= yeoman.dist %>/index.html': '<%%= yeoman.dist %>/index.html'
+        }
+      }
     }
   });
 
@@ -420,7 +432,8 @@ module.exports = function (grunt) {
     'cssmin',
     'uglify',
     'rev',
-    'usemin'
+    'usemin',
+    'targethtml'
   ]);
 
   grunt.registerTask('default', [

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -26,7 +26,8 @@
     "grunt-usemin": "~2.0.0",
     "jshint-stylish": "~0.1.3",
     "load-grunt-tasks": "~0.2.0",
-    "time-grunt": "~0.2.1"
+    "time-grunt": "~0.2.1",
+    "grunt-targethtml": "~0.2.6"
   },
   "engines": {
     "node": ">=0.8.0"

--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -10,6 +10,9 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+    <!--(if target dist)>
+    <base href="{{base}}" />
+    <!(endif)-->
   </head>
   <body ng-app="<%= scriptAppName %>">
     <!--[if lt IE 7]>


### PR DESCRIPTION
To be able flexible configure resources base tag, depending on actual deployment folder.

I use to deploy client side application directly to github via gh-page. If application use client-side routing or accessing resources by relative path that application would not work there.

Added grunt-targethtml task to configure the base html tag.

Examples, 

`http://example.com` => base: '/';
`http://example.com/dashboard` => base: '/dashboard/';

using that would make app work in any virtual directory.
