### PR TITLE
Create a dedicated spec file for factories

### DIFF
--- a/factory/index.js
+++ b/factory/index.js
@@ -12,7 +12,7 @@ util.inherits(Generator, ScriptBase);
 Generator.prototype.createServiceFiles = function createServiceFiles() {
   this.generateSourceAndTest(
     'service/factory',
-    'spec/service',
+    'spec/factory',
     'services',
     this.options['skip-add'] || false
   );

--- a/templates/coffeescript-min/spec/factory.coffee
+++ b/templates/coffeescript-min/spec/factory.coffee
@@ -1,0 +1,14 @@
+'use strict'
+
+describe 'Service: <%= cameledName %>', () ->
+
+  # load the service's module
+  beforeEach module '<%= scriptAppName %>'
+
+  # instantiate service
+  <%= cameledName %> = {}
+  beforeEach inject (_<%= cameledName %>_) ->
+    <%= cameledName %> = _<%= cameledName %>_
+
+  it 'should do something', () ->
+    expect(!!<%= cameledName %>).toBe true

--- a/templates/coffeescript/spec/factory.coffee
+++ b/templates/coffeescript/spec/factory.coffee
@@ -1,0 +1,14 @@
+'use strict'
+
+describe 'Service: <%= cameledName %>', () ->
+
+  # load the service's module
+  beforeEach module '<%= scriptAppName %>'
+
+  # instantiate service
+  <%= cameledName %> = {}
+  beforeEach inject (_<%= cameledName %>_) ->
+    <%= cameledName %> = _<%= cameledName %>_
+
+  it 'should do something', () ->
+    expect(!!<%= cameledName %>).toBe true

--- a/templates/javascript-min/spec/factory.js
+++ b/templates/javascript-min/spec/factory.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('Service: <%= cameledName %>', function () {
+
+  // load the service's module
+  beforeEach(module('<%= scriptAppName %>'));
+
+  // instantiate service
+  var <%= cameledName %>;
+  beforeEach(inject(function(_<%= cameledName %>_) {
+    <%= cameledName %> = _<%= cameledName %>_;
+  }));
+
+  it('should do something', function () {
+    expect(!!<%= cameledName %>).toBe(true);
+  });
+
+});

--- a/templates/javascript/spec/factory.js
+++ b/templates/javascript/spec/factory.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('Service: <%= cameledName %>', function () {
+
+  // load the service's module
+  beforeEach(module('<%= scriptAppName %>'));
+
+  // instantiate service
+  var <%= cameledName %>;
+  beforeEach(inject(function (_<%= cameledName %>_) {
+    <%= cameledName %> = _<%= cameledName %>_;
+  }));
+
+  it('should do something', function () {
+    expect(!!<%= cameledName %>).toBe(true);
+  });
+
+});


### PR DESCRIPTION
The classified name in the spec works fine for services, but causes tests to fail with factories which have a camelized name. Seems the simplest solution (aside from find & replace every time I generate a factory) is to just have a different spec file for factories.
