### PR TITLE
fix(app): services use classified names

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -106,6 +106,11 @@ Generator.prototype.addScriptToIndex = function (script) {
 };
 
 Generator.prototype.generateSourceAndTest = function (appTemplate, testTemplate, targetDirectory, skipAdd) {
+  // Services use classified names
+  if (this.generatorName.toLowerCase() === 'service') {
+    this.cameledName = this.classedName;
+  }
+
   this.appTemplate(appTemplate, path.join('scripts', targetDirectory, this.name));
   this.testTemplate(testTemplate, path.join(targetDirectory, this.name));
   if (!skipAdd) {

--- a/templates/coffeescript-min/spec/service.coffee
+++ b/templates/coffeescript-min/spec/service.coffee
@@ -1,14 +1,14 @@
 'use strict'
 
-describe 'Service: <%= classedName %>', () ->
+describe 'Service: <%= cameledName %>', () ->
 
   # load the service's module
   beforeEach module '<%= scriptAppName %>'
 
   # instantiate service
-  <%= classedName %> = {}
-  beforeEach inject (_<%= classedName %>_) ->
-    <%= classedName %> = _<%= classedName %>_
+  <%= cameledName %> = {}
+  beforeEach inject (_<%= cameledName %>_) ->
+    <%= cameledName %> = _<%= cameledName %>_
 
   it 'should do something', () ->
-    expect(!!<%= classedName %>).toBe true
+    expect(!!<%= cameledName %>).toBe true

--- a/templates/coffeescript/spec/service.coffee
+++ b/templates/coffeescript/spec/service.coffee
@@ -1,14 +1,14 @@
 'use strict'
 
-describe 'Service: <%= classedName %>', () ->
+describe 'Service: <%= cameledName %>', () ->
 
   # load the service's module
   beforeEach module '<%= scriptAppName %>'
 
   # instantiate service
-  <%= classedName %> = {}
-  beforeEach inject (_<%= classedName %>_) ->
-    <%= classedName %> = _<%= classedName %>_
+  <%= cameledName %> = {}
+  beforeEach inject (_<%= cameledName %>_) ->
+    <%= cameledName %> = _<%= cameledName %>_
 
   it 'should do something', () ->
-    expect(!!<%= classedName %>).toBe true
+    expect(!!<%= cameledName %>).toBe true

--- a/templates/javascript-min/spec/service.js
+++ b/templates/javascript-min/spec/service.js
@@ -1,18 +1,18 @@
 'use strict';
 
-describe('Service: <%= classedName %>', function () {
+describe('Service: <%= cameledName %>', function () {
 
   // load the service's module
   beforeEach(module('<%= scriptAppName %>'));
 
   // instantiate service
-  var <%= classedName %>;
-  beforeEach(inject(function(_<%= classedName %>_) {
-    <%= classedName %> = _<%= classedName %>_;
+  var <%= cameledName %>;
+  beforeEach(inject(function(_<%= cameledName %>_) {
+    <%= cameledName %> = _<%= cameledName %>_;
   }));
 
   it('should do something', function () {
-    expect(!!<%= classedName %>).toBe(true);
+    expect(!!<%= cameledName %>).toBe(true);
   });
 
 });

--- a/templates/javascript/spec/service.js
+++ b/templates/javascript/spec/service.js
@@ -1,18 +1,18 @@
 'use strict';
 
-describe('Service: <%= classedName %>', function () {
+describe('Service: <%= cameledName %>', function () {
 
   // load the service's module
   beforeEach(module('<%= scriptAppName %>'));
 
   // instantiate service
-  var <%= classedName %>;
-  beforeEach(inject(function (_<%= classedName %>_) {
-    <%= classedName %> = _<%= classedName %>_;
+  var <%= cameledName %>;
+  beforeEach(inject(function (_<%= cameledName %>_) {
+    <%= cameledName %> = _<%= cameledName %>_;
   }));
 
   it('should do something', function () {
-    expect(!!<%= classedName %>).toBe(true);
+    expect(!!<%= cameledName %>).toBe(true);
   });
 
 });

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -167,8 +167,8 @@ describe('Angular generator', function () {
 
   describe('Service', function () {
     function serviceTest (generatorType, nameFn, done) {
-      generatorTest(generatorType, 'service', 'services', nameFn, _.classify, '', done);
-    };
+      generatorTest(generatorType, 'service', 'services', nameFn, nameFn, '', done);
+    }
 
     it('should generate a new constant', function (done) {
       serviceTest('constant', _.camelize, done);


### PR DESCRIPTION
Fix app tests that used cameled service names instead of classified
names.
