### PR TITLE
Changed grunt development server port to 9003 to combat common port collisions with other applicaitons

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -73,7 +73,7 @@ module.exports = function (grunt) {
     // The actual grunt server settings
     connect: {
       options: {
-        port: 9000,
+        port: 9003,
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
         livereload: 35729


### PR DESCRIPTION
`9000` is a common port used by various applications. In order to prevent port collisions, I switched the grunt development server to port `9003`.

Some common collisions which can be foreseen occurring on port 9000:
xdebug on Eclipse
xdebug on Sublime Text
xdebug on NetBeans
xdebug on PHPStorm
... basically any IDE with xdebug integrated.
[play framework](http://www.playframework.com/) runs on port 9000

The internet is riddled with why can't I use `X` on port 9000. Let's avoid that head ache.
