### PR TITLE
Use grunt-bower-install for HTML dependency injection.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,9 +1,11 @@
 'use strict';
+var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var angularUtils = require('../util.js');
-var spawn = require('child_process').spawn;
 var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
+var wiredep = require('wiredep');
 
 
 var Generator = module.exports = function Generator(args, options) {
@@ -66,7 +68,10 @@ var Generator = module.exports = function Generator(args, options) {
   });
 
   this.on('end', function () {
-    this.installDependencies({ skipInstall: this.options['skip-install'] });
+    this.installDependencies({
+      skipInstall: this.options['skip-install'],
+      callback: this._injectDependencies.bind(this)
+    });
 
     var enabledComponents = [];
 
@@ -97,9 +102,10 @@ var Generator = module.exports = function Generator(args, options) {
         ].concat(enabledComponents)
       }
     });
+
   });
 
-  this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
+  this.pkg = require(__dirname, '../package.json');
 };
 
 util.inherits(Generator, yeoman.generators.Base);
@@ -213,78 +219,18 @@ Generator.prototype.readIndex = function readIndex() {
 // Waiting a more flexible solution for #138
 Generator.prototype.bootstrapFiles = function bootstrapFiles() {
   var sass = this.compassBootstrap;
-  var files = [];
   var source = 'styles/' + ( sass ? 's' : '' ) + 'css/';
+  var dest = 'app/styles/';
+  var mainFile = 'main.' + (sass ? 's' : '') + 'css';
 
   if (this.bootstrap && !sass) {
-    files.push('bootstrap.css');
     this.copy('fonts/glyphicons-halflings-regular.eot', 'app/fonts/glyphicons-halflings-regular.eot');
     this.copy('fonts/glyphicons-halflings-regular.ttf', 'app/fonts/glyphicons-halflings-regular.ttf');
     this.copy('fonts/glyphicons-halflings-regular.svg', 'app/fonts/glyphicons-halflings-regular.svg');
     this.copy('fonts/glyphicons-halflings-regular.woff', 'app/fonts/glyphicons-halflings-regular.woff');
   }
 
-  files.push('main.' + (sass ? 's' : '') + 'css');
-
-  files.forEach(function (file) {
-    this.copy(source + file, 'app/styles/' + file);
-  }.bind(this));
-
-  this.indexFile = this.appendFiles({
-    html: this.indexFile,
-    fileType: 'css',
-    optimizedPath: 'styles/main.css',
-    sourceFileList: files.map(function (file) {
-      return 'styles/' + file.replace('.scss', '.css');
-    }),
-    searchPath: ['.tmp', 'app']
-  });
-};
-
-Generator.prototype.bootstrapJS = function bootstrapJS() {
-  if (!this.bootstrap) {
-    return;  // Skip if disabled.
-  }
-
-  // Wire Twitter Bootstrap plugins
-  this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
-    'bower_components/sass-bootstrap/js/affix.js',
-    'bower_components/sass-bootstrap/js/alert.js',
-    'bower_components/sass-bootstrap/js/button.js',
-    'bower_components/sass-bootstrap/js/carousel.js',
-    'bower_components/sass-bootstrap/js/transition.js',
-    'bower_components/sass-bootstrap/js/collapse.js',
-    'bower_components/sass-bootstrap/js/dropdown.js',
-    'bower_components/sass-bootstrap/js/modal.js',
-    'bower_components/sass-bootstrap/js/scrollspy.js',
-    'bower_components/sass-bootstrap/js/tab.js',
-    'bower_components/sass-bootstrap/js/tooltip.js',
-    'bower_components/sass-bootstrap/js/popover.js'
-  ]);
-};
-
-Generator.prototype.extraModules = function extraModules() {
-  var modules = [];
-  if (this.resourceModule) {
-    modules.push('bower_components/angular-resource/angular-resource.js');
-  }
-
-  if (this.cookiesModule) {
-    modules.push('bower_components/angular-cookies/angular-cookies.js');
-  }
-
-  if (this.sanitizeModule) {
-    modules.push('bower_components/angular-sanitize/angular-sanitize.js');
-  }
-
-  if (this.routeModule) {
-    modules.push('bower_components/angular-route/angular-route.js');
-  }
-
-  if (modules.length) {
-    this.indexFile = this.appendScripts(this.indexFile, 'scripts/modules.js',
-        modules);
-  }
+  this.copy(source + mainFile, dest + mainFile);
 };
 
 Generator.prototype.appJs = function appJs() {
@@ -312,4 +258,24 @@ Generator.prototype.packageFiles = function () {
 Generator.prototype.imageFiles = function () {
   this.sourceRoot(path.join(__dirname, 'templates'));
   this.directory('images', 'app/images', true);
+}
+
+Generator.prototype._injectDependencies = function _injectDependencies() {
+  var howToInstall =
+    '\nAfter running `npm install & bower install`, inject your front end dependencies into' +
+    '\nyour HTML by running:' +
+    '\n' +
+    chalk.yellow.bold('\n  grunt bower-install');
+
+  if (this.options['skip-install']) {
+    console.log(howToInstall);
+  } else {
+    wiredep({
+      directory: 'app/bower_components',
+      bowerJson: JSON.parse(fs.readFileSync('./bower.json')),
+      ignorePath: 'app/',
+      htmlFile: 'app/index.html',
+      cssPattern: '<link rel="stylesheet" href="{{filePath}}">'
+    });
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.13.0"
+    "yeoman-generator": "~0.13.0",
+    "chalk": "~0.3.0",
+    "wiredep": "~0.4.2"
   },
   "peerDependencies": {
     "generator-karma": "~0.6.0",

--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -152,6 +152,14 @@ module.exports = function (grunt) {
       }
     },
 
+    // Automatically inject Bower components into the HTML file
+    'bower-install': {
+      app: {
+        html: '<%%= yeoman.app %>/index.html',
+        ignorePath: '<%%= yeoman.app %>/'
+      }
+    },
+
 <% if (coffee) { %>
     // Compiles CoffeeScript to JavaScript
     coffee: {

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",
+    "grunt-bower-install": "~0.7.0",
     "grunt-concurrent": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-coffee": "~0.7.0",

--- a/templates/common/index.html
+++ b/templates/common/index.html
@@ -10,15 +10,17 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+    <!-- build:css styles/vendor.css -->
+    <!-- bower:css -->
+    <!-- endbower -->
+    <!-- endbuild -->
+    <!-- build:css({.tmp,app}) styles/main.css -->
+    <link rel="stylesheet" href="styles/main.css">
+    <!-- endbuild -->
   </head>
   <body ng-app="<%= scriptAppName %>">
     <!--[if lt IE 7]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
-    <![endif]-->
-
-    <!--[if lt IE 9]>
-      <script src="bower_components/es5-shim/es5-shim.js"></script>
-      <script src="bower_components/json3/lib/json3.min.js"></script>
     <![endif]-->
 
     <!-- Add your site or application content here -->
@@ -39,7 +41,14 @@
        ga('send', 'pageview');
     </script>
 
-    <% if (bootstrap) { %><script src="bower_components/jquery/jquery.js"></script><% } %>
-    <script src="bower_components/angular/angular.js"></script>
+    <!--[if lt IE 9]>
+    <script src="bower_components/es5-shim/es5-shim.js"></script>
+    <script src="bower_components/json3/lib/json3.min.js"></script>
+    <![endif]-->
+
+    <!-- build:js scripts/vendor.js -->
+    <!-- bower:js -->
+    <!-- endbower -->
+    <!-- endbuild -->
   </body>
 </html>


### PR DESCRIPTION
To sync up the generators, I added `grunt-bower-install` here. It definitely needs to be tested, and my computer is in a :poop:-y state for that. So, I thought I'd see if anyone here had a chance.

It turns out this isn't only nice for users, who will be able to inject dependencies automatically, but it's also created for some easier generator authoring. Less JS ifs, and more "let ~~grunt-bower-install~~ wiredep handle it." ~~I attached a `spawnCommand('grunt', ['bower-install'])` callback after the scaffold finishes installing the NPM and Bower dependencies. Not sure if that's a good idea, best practice wise, but it works!~~
