### PR TITLE
Fixed bug which caused buttons to have a height of 33px instead of 34px

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -194,7 +194,8 @@ module.exports = function (grunt) {
         httpGeneratedImagesPath: '/images/generated',
         httpFontsPath: '/styles/fonts',
         relativeAssets: false,
-        assetCacheBuster: false
+        assetCacheBuster: false,
+        raw: "Sass::Script::Number.precision = 10\n"
       },
       dist: {
         options: {


### PR DESCRIPTION
Hi there,

I had a strange bug today in my chrome browser which caused bootstrap buttons to have a height of 33px instead of the usual 34px. After some research, I found out that its a know issue and can be fixed by increasing the the precision of the sass compiler.

Cheers,
Peer

Found cause and fix here: 
thomas-mcdonald/bootstrap-sass#409
gruntjs/grunt-contrib-compass#113
