### PR TITLE
feat(app): add jasmine browser global to test jshintrc

### DIFF
--- a/templates/common/root/test/.jshintrc
+++ b/templates/common/root/test/.jshintrc
@@ -29,6 +29,7 @@
     "expect": false,
     "inject": false,
     "it": false,
+    "jasmine": false,
     "spyOn": false
   }
 }


### PR DESCRIPTION
JSHint fails if you refer to `jasmine` in your tests, e.g. `jasmine.createSpy()`. Allowing this seems like a sane default.
