### PR TITLE
How should we handle AngularJS pre-releases?

### DIFF
--- a/templates/common/_bower.json
+++ b/templates/common/_bower.json
@@ -2,19 +2,19 @@
   "name": "<%= _.slugify(_.humanize(appname)) %>",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "~1.2.5",
+    "angular": "1.2.5",
     "json3": "~3.2.6",
     "es5-shim": "~2.1.0"<% if (bootstrap) { %>,
     "jquery": "~1.10.2"<% if (compassBootstrap) { %>,
     "sass-bootstrap": "~3.0.2"<% } else { %>,
     "bootstrap": "~3.0.3"<% } } %><% if (resourceModule) { %>,
-    "angular-resource": "~1.2.5"<% } %><% if (cookiesModule) { %>,
-    "angular-cookies": "~1.2.5"<% } %><% if (sanitizeModule) { %>,
-    "angular-sanitize": "~1.2.5"<% } %><% if (routeModule) { %>,
-    "angular-route": "~1.2.5"<% } %>
+    "angular-resource": "1.2.5"<% } %><% if (cookiesModule) { %>,
+    "angular-cookies": "1.2.5"<% } %><% if (sanitizeModule) { %>,
+    "angular-sanitize": "1.2.5"<% } %><% if (routeModule) { %>,
+    "angular-route": "1.2.5"<% } %>
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.5",
-    "angular-scenario": "~1.2.5"
+    "angular-mocks": "1.2.5",
+    "angular-scenario": "1.2.5"
   }
 }


### PR DESCRIPTION
AngularJS started publishing pre-releases that unfortunately get picked up with the tilde specifier. How should we handle that? I don't really like defaulting to using unstable releases. Is there anything better we can do than hard-pinning the version?
