### PR TITLE
fix(build:sass): increases numeric precision of sass compiler

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -202,7 +202,8 @@ module.exports = function (grunt) {
         httpGeneratedImagesPath: '/images/generated',
         httpFontsPath: '/styles/fonts',
         relativeAssets: false,
-        assetCacheBuster: false
+        assetCacheBuster: false,
+        raw: "Sass::Script::Number.precision = 10\n"
       },
       dist: {
         options: {


### PR DESCRIPTION
Buttons now match the height of inputs, when using them as input groups.

Previous [pull request](https://github.com/yeoman/generator-angular/pull/500).
