### PR TITLE
fix(gruntfile): copy fonts from bootstrap 3 bower directory to dist/fonts folder

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -330,7 +330,16 @@ module.exports = function (grunt) {
           cwd: '.tmp/images',
           dest: '<%%= yeoman.dist %>/images',
           src: ['generated/*']
-        }]
+        }
+        <% if (bootstrap && compass && !compassBootstrap) { %>
+        , {
+          expand:true,
+          cwd: '<%%= yeoman.app %>/bower_components/bootstrap/dist',
+          src: 'fonts/*',
+          dest: '<%%= yeoman.dist %>'
+        }
+        <% } %>
+        ]
       },
       styles: {
         expand: true,


### PR DESCRIPTION
It is only required if using bootstrap and compass but not the
sass version of bootstrap
