### PR TITLE
style: remove superfluous parentheses from coffeescript templates

### DIFF
--- a/templates/coffeescript-min/filter.coffee
+++ b/templates/coffeescript-min/filter.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 angular.module('<%= scriptAppName %>')
-  .filter '<%= cameledName %>', [() ->
+  .filter '<%= cameledName %>', [->
     (input) ->
       '<%= cameledName %> filter: ' + input
   ]

--- a/templates/coffeescript-min/service/factory.coffee
+++ b/templates/coffeescript-min/service/factory.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 angular.module('<%= scriptAppName %>')
-  .factory '<%= cameledName %>', [() ->
+  .factory '<%= cameledName %>', [->
     # Service logic
     # ...
 
@@ -9,7 +9,7 @@ angular.module('<%= scriptAppName %>')
 
     # Public API here
     {
-      someMethod: () ->
+      someMethod: ->
         meaningOfLife
     }
   ]

--- a/templates/coffeescript-min/service/service.coffee
+++ b/templates/coffeescript-min/service/service.coffee
@@ -1,5 +1,5 @@
 'use strict'
 
 angular.module('<%= scriptAppName %>')
-  .service '<%= classedName %>', () ->
+  .service '<%= classedName %>', ->
     # AngularJS will instantiate a singleton by calling "new" on this function

--- a/templates/coffeescript-min/spec/controller.coffee
+++ b/templates/coffeescript-min/spec/controller.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Controller: <%= classedName %>Ctrl', () ->
+describe 'Controller: <%= classedName %>Ctrl', ->
 
   # load the controller's module
   beforeEach module '<%= scriptAppName %>'
@@ -15,5 +15,5 @@ describe 'Controller: <%= classedName %>Ctrl', () ->
       $scope: scope
     }
 
-  it 'should attach a list of awesomeThings to the scope', () ->
+  it 'should attach a list of awesomeThings to the scope', ->
     expect(scope.awesomeThings.length).toBe 3

--- a/templates/coffeescript-min/spec/directive.coffee
+++ b/templates/coffeescript-min/spec/directive.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Directive: <%= cameledName %>', () ->
+describe 'Directive: <%= cameledName %>', ->
 
   # load the directive's module
   beforeEach module '<%= scriptAppName %>'

--- a/templates/coffeescript-min/spec/filter.coffee
+++ b/templates/coffeescript-min/spec/filter.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Filter: <%= cameledName %>', () ->
+describe 'Filter: <%= cameledName %>', ->
 
   # load the filter's module
   beforeEach module '<%= scriptAppName %>'
@@ -10,6 +10,6 @@ describe 'Filter: <%= cameledName %>', () ->
   beforeEach inject ($filter) ->
     <%= cameledName %> = $filter '<%= cameledName %>'
 
-  it 'should return the input prefixed with "<%= cameledName %> filter:"', () ->
+  it 'should return the input prefixed with "<%= cameledName %> filter:"', ->
     text = 'angularjs'
     expect(<%= cameledName %> text).toBe ('<%= cameledName %> filter: ' + text)

--- a/templates/coffeescript-min/spec/service.coffee
+++ b/templates/coffeescript-min/spec/service.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Service: <%= cameledName %>', () ->
+describe 'Service: <%= cameledName %>', ->
 
   # load the service's module
   beforeEach module '<%= scriptAppName %>'
@@ -10,5 +10,5 @@ describe 'Service: <%= cameledName %>', () ->
   beforeEach inject (_<%= cameledName %>_) ->
     <%= cameledName %> = _<%= cameledName %>_
 
-  it 'should do something', () ->
+  it 'should do something', ->
     expect(!!<%= cameledName %>).toBe true

--- a/templates/coffeescript/directive.coffee
+++ b/templates/coffeescript/directive.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 angular.module('<%= scriptAppName %>')
-  .directive('<%= cameledName %>', () ->
+  .directive('<%= cameledName %>', ->
     template: '<div></div>'
     restrict: 'E'
     link: (scope, element, attrs) ->

--- a/templates/coffeescript/filter.coffee
+++ b/templates/coffeescript/filter.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
 angular.module('<%= scriptAppName %>')
-  .filter '<%= cameledName %>', () ->
+  .filter '<%= cameledName %>', ->
     (input) ->
       '<%= cameledName %> filter: ' + input

--- a/templates/coffeescript/service/factory.coffee
+++ b/templates/coffeescript/service/factory.coffee
@@ -1,7 +1,7 @@
 'use strict'
 
 angular.module('<%= scriptAppName %>')
-  .factory '<%= cameledName %>', () ->
+  .factory '<%= cameledName %>', ->
     # Service logic
     # ...
 
@@ -9,6 +9,6 @@ angular.module('<%= scriptAppName %>')
 
     # Public API here
     {
-      someMethod: () ->
+      someMethod: ->
         meaningOfLife
     }

--- a/templates/coffeescript/service/service.coffee
+++ b/templates/coffeescript/service/service.coffee
@@ -1,5 +1,5 @@
 'use strict'
 
 angular.module('<%= scriptAppName %>')
-  .service '<%= classedName %>', () ->
+  .service '<%= classedName %>', ->
     # AngularJS will instantiate a singleton by calling "new" on this function

--- a/templates/coffeescript/spec/controller.coffee
+++ b/templates/coffeescript/spec/controller.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Controller: <%= classedName %>Ctrl', () ->
+describe 'Controller: <%= classedName %>Ctrl', ->
 
   # load the controller's module
   beforeEach module '<%= scriptAppName %>'
@@ -15,5 +15,5 @@ describe 'Controller: <%= classedName %>Ctrl', () ->
       $scope: scope
     }
 
-  it 'should attach a list of awesomeThings to the scope', () ->
+  it 'should attach a list of awesomeThings to the scope', ->
     expect(scope.awesomeThings.length).toBe 3

--- a/templates/coffeescript/spec/directive.coffee
+++ b/templates/coffeescript/spec/directive.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Directive: <%= cameledName %>', () ->
+describe 'Directive: <%= cameledName %>', ->
 
   # load the directive's module
   beforeEach module '<%= scriptAppName %>'

--- a/templates/coffeescript/spec/filter.coffee
+++ b/templates/coffeescript/spec/filter.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Filter: <%= cameledName %>', () ->
+describe 'Filter: <%= cameledName %>', ->
 
   # load the filter's module
   beforeEach module '<%= scriptAppName %>'
@@ -10,6 +10,6 @@ describe 'Filter: <%= cameledName %>', () ->
   beforeEach inject ($filter) ->
     <%= cameledName %> = $filter '<%= cameledName %>'
 
-  it 'should return the input prefixed with "<%= cameledName %> filter:"', () ->
+  it 'should return the input prefixed with "<%= cameledName %> filter:"', ->
     text = 'angularjs'
     expect(<%= cameledName %> text).toBe ('<%= cameledName %> filter: ' + text)

--- a/templates/coffeescript/spec/service.coffee
+++ b/templates/coffeescript/spec/service.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-describe 'Service: <%= cameledName %>', () ->
+describe 'Service: <%= cameledName %>', ->
 
   # load the service's module
   beforeEach module '<%= scriptAppName %>'
@@ -10,5 +10,5 @@ describe 'Service: <%= cameledName %>', () ->
   beforeEach inject (_<%= cameledName %>_) ->
     <%= cameledName %> = _<%= cameledName %>_
 
-  it 'should do something', () ->
+  it 'should do something', ->
     expect(!!<%= cameledName %>).toBe true


### PR DESCRIPTION
the following reasons for this PR are in priority order:

1) consistency, the following files already omit the unneeded parens
     /templates/coffeescript/service/provider.coffee
     /templates/coffeescript-min/service/provider.coffee
     /templates/coffeescript-min/directive.coffee

2) this change is similar to unneeded semicolons (e38124ee)

3) all function examples that don't take arguments on
   coffeescript.org also don't have empty parens

My team and I use this generator daily, and are trying to adhere to
the following: https://github.com/polarmobile/coffeescript-style-guide
