### PR TITLE
fix(useminPrepare): rewrite relative CSS urls

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -237,7 +237,16 @@ module.exports = function (grunt) {
     useminPrepare: {
       html: '<%%= yeoman.app %>/index.html',
       options: {
-        dest: '<%%= yeoman.dist %>'
+        dest: '<%%= yeoman.dist %>',
+        flow: {
+          html: {
+            steps: {
+              js: ['concat', 'uglifyjs'],
+              css: ['cssmin']
+            },
+            post: {}
+          }
+        }
       }
     },
 
@@ -251,6 +260,11 @@ module.exports = function (grunt) {
     },
 
     // The following *-min tasks produce minified files in the dist folder
+    cssmin: {
+      options: {
+        root: '<%%= yeoman.app %>'
+      }
+    },
     imagemin: {
       dist: {
         files: [{


### PR DESCRIPTION
First, tell useminPrepare to only 'cssmin' our CSS files (dropping the
concat task). See https://github.com/yeoman/grunt-usemin/issues/225.
Second, tell cssmin to rewrite relative urls to be relative to our app
directory.

This is particularly useful for bower install components that have CSS
files that reference relative urls. ie.

```
.
├── app
│   └── bower_components
│       └── component
│           ├── images
│           │   └── image.png
│           └── style.css
└── build
```

```
body {
background: url('images/image.png');
}
```

Will have now properly rewrite it's image url to

```
body {
background: url('bower_components/component/images/image.png');
}
```
