### PR TITLE
fix(dependencies): updated imagemin version

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-contrib-imagemin": "~0.3.0",
+    "grunt-contrib-imagemin": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.2",


### PR DESCRIPTION
version 0.3.0 of imagemin has a broken dependency
which is fixed in the latest version
