### PR TITLE
Update grunt-newer

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.2",
     "grunt-google-cdn": "~0.2.0",
-    "grunt-newer": "~0.5.4",
+    "grunt-newer": "~0.6.1",
     "grunt-ngmin": "~0.0.2",
     "grunt-rev": "~0.1.0",
     "grunt-svgmin": "~0.2.0",


### PR DESCRIPTION
The 0.6 release deprecates the "any-newer" task (which you were not using) and folds the same functionality into the "newer" task.  See the [changelog](https://github.com/tschaub/grunt-newer/blob/master/changelog.md) for more detail.  This avoids issues like tschaub/grunt-newer#31.
