### PR TITLE
upgrade to wiredep & grunt-bower-install 1.0

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -269,7 +269,7 @@ Generator.prototype._injectDependencies = function _injectDependencies() {
     '\nAfter running `npm install & bower install`, inject your front end dependencies into' +
     '\nyour HTML by running:' +
     '\n' +
-    chalk.yellow.bold('\n  grunt bower-install');
+    chalk.yellow.bold('\n  grunt bowerInstall');
 
   if (this.options['skip-install']) {
     console.log(howToInstall);
@@ -278,8 +278,14 @@ Generator.prototype._injectDependencies = function _injectDependencies() {
       directory: 'app/bower_components',
       bowerJson: JSON.parse(fs.readFileSync('./bower.json')),
       ignorePath: 'app/',
-      htmlFile: 'app/index.html',
-      cssPattern: '<link rel="stylesheet" href="{{filePath}}">'
+      src: 'app/index.html',
+      fileTypes: {
+        html: {
+          replace: {
+            css: '<link rel="stylesheet" href="{{filePath}}">'
+          }
+        }
+      }
     });
   }
 };

--- a/app/templates/styles/main.scss
+++ b/app/templates/styles/main.scss
@@ -2,7 +2,10 @@
 
 @import 'sass-bootstrap/lib/bootstrap';
 
-<% } %>.browsehappy {
+<% } %>// bower:scss
+// endbower
+
+.browsehappy {
     margin: 0.2em 0;
     background: #ccc;
     color: #000;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "chalk": "~0.4.0",
-    "wiredep": "~0.4.2",
+    "wiredep": "~1.0.0",
     "yeoman-generator": "~0.16.0"
   },
   "peerDependencies": {

--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -153,14 +153,17 @@ module.exports = function (grunt) {
     },
 
     // Automatically inject Bower components into the app
-    'bower-install': {
+    bowerInstall: {
       app: {
-        html: '<%%= yeoman.app %>/index.html',
+        src: ['<%%= yeoman.app %>/index.html'],
         ignorePath: '<%%= yeoman.app %>/'
-      }
-    },
+      }<% if (compass) { %>,
+      sass: {
+        src: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+        ignorePath: '<%%= yeoman.app %>/bower_components/'
+      }<% } %>
+    },<% if (coffee) { %>
 
-<% if (coffee) { %>
     // Compiles CoffeeScript to JavaScript
     coffee: {
       options: {
@@ -185,9 +188,8 @@ module.exports = function (grunt) {
           ext: '.js'
         }]
       }
-    },<% } %>
+    },<% } %><% if (compass) { %>
 
-<% if (compass) { %>
     // Compiles Sass to CSS and generates necessary files if requested
     compass: {
       options: {
@@ -265,6 +267,7 @@ module.exports = function (grunt) {
         root: '<%%= yeoman.app %>'
       }
     },
+
     imagemin: {
       dist: {
         files: [{
@@ -275,6 +278,7 @@ module.exports = function (grunt) {
         }]
       }
     },
+
     svgmin: {
       dist: {
         files: [{
@@ -285,6 +289,7 @@ module.exports = function (grunt) {
         }]
       }
     },
+
     htmlmin: {
       dist: {
         options: {
@@ -419,7 +424,7 @@ module.exports = function (grunt) {
 
     grunt.task.run([
       'clean:server',
-      'bower-install',
+      'bowerInstall',
       'concurrent:server',
       'autoprefixer',
       'connect:livereload',
@@ -442,7 +447,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('build', [
     'clean:dist',
-    'bower-install',
+    'bowerInstall',
     'useminPrepare',
     'concurrent:dist',
     'autoprefixer',

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",
-    "grunt-bower-install": "~0.7.0",
+    "grunt-bower-install": "~1.0.0",
     "grunt-concurrent": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",<% if (coffee) { %>
     "grunt-contrib-coffee": "~0.7.0",<% } %><% if (compass) { %>


### PR DESCRIPTION
I released `wiredep` and `grunt-bower-install` 1.0 over the weekend. Aside from a few configuration details being changed, it also added support for other file types. One of them is .sass/.scss. I added a `// bower:scss` block in  `main.scss`, which will allow users to run something like `bower install --save modular-scale && grunt bowerInstall` to have it injected.

That changes in the Gruntfile are just formatting changes, to avoid this kind of thing:

``` js
grunt.initConfig({
  task1: {
  },



  task2: {
  }
});
```

I've tested it, and it all seems to be working well. Any extra eyes on this would be great! If I don't hear back in a couple days, I'll just assume all is well and hit the green button :+1: 
