### PR TITLE
Update `grunt-contrib-compass` dependency to ~0.7

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -9,7 +9,7 @@
     "grunt-concurrent": "~0.4.1",
     "grunt-contrib-clean": "~0.5.0",<% if (coffee) { %>
     "grunt-contrib-coffee": "~0.7.0",<% } %><% if (compass) { %>
-    "grunt-contrib-compass": "~0.6.0",<% } %>
+    "grunt-contrib-compass": "~0.7.0",<% } %>
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",


### PR DESCRIPTION
Otherwise Windows machines which haven't installed Compass will get a 'cannot read property stdout of undefined', because of a (now fixed) bug in `grunt-contrib-compass`

This took me some time to figure out on my work-Windows machine, and it'll probably save some time for a lot of other unlucky Windows guys.
