### PR TITLE
fix(build): don't copy the bower_components folder in build

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -345,7 +345,6 @@ module.exports = function (grunt) {
             '.htaccess',
             '*.html',
             'views/{,*/}*.html',
-            'bower_components/**/*',
             'images/{,*/}*.{webp}',
             'fonts/*'
           ]


### PR DESCRIPTION
This changes the default copy of the `bower_components` to not copy it
during `grunt build` to the _/dist_ folder. **bowerInstall** should copy
the needed files into the _index.html_ so **usemin** can process them.
If the files don't confirm to the Bower spec, a user can manually add a
line in the _index.html_ file so they are included in the build process.

Fixes #590

BREAKING CHANGE: bower_components is no longer copied into the /dist
folder.
