### PR TITLE
feat(Gruntfile): use grunt devtools

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -15,6 +15,9 @@ module.exports = function (grunt) {
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
 
+  // Load `devtools` task to link Chrome extension
+  require('grunt-devtools')(grunt);
+
   // Define the configuration for all the tasks
   grunt.initConfig({
 

--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -27,7 +27,8 @@
     "grunt-usemin": "~2.0.0",
     "jshint-stylish": "~0.1.3",
     "load-grunt-tasks": "~0.4.0",
-    "time-grunt": "~0.2.1"
+    "time-grunt": "~0.2.1",
+    "grunt-devtools": "~0.2.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
use grunt **devtools** plugin by default, allowing chrome extension to be linked automatically and grunt tasks to be easily triggered directly inside devtools window

no breaking change
