### PR TITLE
fix(gruntfile): watch subdirectories at any level without killing cpu

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -32,30 +32,30 @@ module.exports = function (grunt) {
         tasks: ['bowerInstall']
       },<% if (coffee) { %>
       coffee: {
-        files: ['<%%= yeoman.app %>/scripts/{,*/}*.{coffee,litcoffee,coffee.md}'],
+        files: ['<%%= yeoman.app %>/scripts/**/*.{coffee,litcoffee,coffee.md}'],
         tasks: ['newer:coffee:dist']
       },
       coffeeTest: {
-        files: ['test/spec/{,*/}*.{coffee,litcoffee,coffee.md}'],
+        files: ['test/spec/**/*.{coffee,litcoffee,coffee.md}'],
         tasks: ['newer:coffee:test', 'karma']
       },<% } else { %>
       js: {
-        files: ['<%%= yeoman.app %>/scripts/{,*/}*.js'],
+        files: ['<%%= yeoman.app %>/scripts/**/*.js'],
         tasks: ['newer:jshint:all'],
         options: {
           livereload: true
         }
       },
       jsTest: {
-        files: ['test/spec/{,*/}*.js'],
+        files: ['test/spec/**/*.js'],
         tasks: ['newer:jshint:test', 'karma']
       },<% } %><% if (compass) { %>
       compass: {
-        files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+        files: ['<%%= yeoman.app %>/styles/**/*.{scss,sass}'],
         tasks: ['compass:server', 'autoprefixer']
       },<% } else { %>
       styles: {
-        files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
+        files: ['<%%= yeoman.app %>/styles/**/*.css'],
         tasks: ['newer:copy:styles', 'autoprefixer']
       },<% } %>
       gruntfile: {
@@ -66,10 +66,11 @@ module.exports = function (grunt) {
           livereload: '<%%= connect.options.livereload %>'
         },
         files: [
-          '<%%= yeoman.app %>/{,*/}*.html',
-          '.tmp/styles/{,*/}*.css',<% if (coffee) { %>
-          '.tmp/scripts/{,*/}*.js',<% } %>
-          '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+          '<%%= yeoman.app %>/*.html',
+          '<%%= yeoman.app %>/views/**/*.html',
+          '.tmp/styles/**/*.css',<% if (coffee) { %>
+          '.tmp/scripts/**/*.js',<% } %>
+          '<%%= yeoman.app %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
         ]
       }
     },


### PR DESCRIPTION
I know this has been heavily discussed before (here, for example: #442), but I didn't find anyone who tried this solution: watching all subdirectories (at any level) in the `app` directory, except for `bower_components`.

`bower_components` is huge (thousands of files, in my new empty scaffolded project it contains **477** files) and I guess it's the one who  increases the cpu usage.

Key lines are 69 and 70 in my commit:

```
'<%%= yeoman.app %>/*.html'
'<%%= yeoman.app %>/views/**/*.html'
```

instead of

```
'<%%= yeoman.app %>/**/*.html'
```

However, I'm not an expert and I wouldn't be surprised if I were wrong. :smiley:
