### PR TITLE
feat(Gruntfile): jshint task change

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -108,7 +108,18 @@ module.exports = function (grunt) {
     jshint: {
       options: {
         jshintrc: '.jshintrc',
-        reporter: require('jshint-stylish')
+        reporter: require('jshint-stylish'),
+        ignores: (function() {
+          var gitignorePath = './.gitignore';
+          if(grunt.file.exists(gitignorePath)) {
+            return grunt.file.read(gitignorePath)
+                    .replace(/(\s|\t|\n)+/g, ' ')
+                    .trim()
+                    .split(/\s/g);
+          }
+          //else
+          return [];
+        })()
       },
       all: [
         'Gruntfile.js'<% if (!coffee) { %>,


### PR DESCRIPTION
I know jshint ignores files from _.jshintignore_, but you don't need to test files that you don't own and version (which are ignored by git), so make jshint ignore the files from _.gitignore_ too
