### PR TITLE
Reactivate minor version updates for angular

### DIFF
--- a/templates/common/_bower.json
+++ b/templates/common/_bower.json
@@ -2,19 +2,19 @@
   "name": "<%= _.slugify(_.humanize(appname)) %>",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "1.2.14",
+    "angular": "~1.2.14",
     "json3": "~3.2.6",
     "es5-shim": "~2.1.0"<% if (bootstrap) { %>,
     "jquery": "~1.11.0"<% if (compassBootstrap) { %>,
     "bootstrap-sass-official": "~3.1.0"<% } else { %>,
     "bootstrap": "~3.0.3"<% } } %><% if (resourceModule) { %>,
-    "angular-resource": "1.2.14"<% } %><% if (cookiesModule) { %>,
-    "angular-cookies": "1.2.14"<% } %><% if (sanitizeModule) { %>,
-    "angular-sanitize": "1.2.14"<% } %><% if (routeModule) { %>,
-    "angular-route": "1.2.14"<% } %>
+    "angular-resource": "~1.2.14"<% } %><% if (cookiesModule) { %>,
+    "angular-cookies": "~1.2.14"<% } %><% if (sanitizeModule) { %>,
+    "angular-sanitize": "~1.2.14"<% } %><% if (routeModule) { %>,
+    "angular-route": "~1.2.14"<% } %>
   },
   "devDependencies": {
-    "angular-mocks": "1.2.14",
-    "angular-scenario": "1.2.14"
+    "angular-mocks": "~1.2.14",
+    "angular-scenario": "~1.2.14"
   }
 }


### PR DESCRIPTION
AngularJS have changed their version naming conventions.

See [here](http://blog.angularjs.org/2013/12/angularjs-13-new-release-approaches.html).

So we won't get unstable releases with '~' anymore.
