### PR TITLE
chore(build): exclude unnecessary js resources during bowerInstall

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -162,7 +162,11 @@ module.exports = function (grunt) {
     bowerInstall: {
       app: {
         src: ['<%%= yeoman.app %>/index.html'],
-        ignorePath: new RegExp('^<%%= yeoman.app %>/')
+        ignorePath: new RegExp('^<%%= yeoman.app %>/')<% if (bootstrap) { %>,
+        exclude: [
+          'jquery'<% if (compassBootstrap) { %>,
+          'bootstrap-sass-official'<% } %>
+        ]<% } %>
       }<% if (compass) { %>,
       sass: {
         src: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],


### PR DESCRIPTION
#538

Didn't update `grunt-bower-isntall` since newer versions of `wiredep` result relative paths `../bower_components` in html.
