### PR TITLE
Add option to choose port when firing up server

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -80,7 +80,7 @@ module.exports = function (grunt) {
         port: grunt.option('port') || 9000,
         // Change this to '0.0.0.0' to access the server from outside.
         hostname: 'localhost',
-        livereload: 35729
+        livereload: grunt.option('livereloadport') || 35729
       },
       livereload: {
         options: {


### PR DESCRIPTION
I find myself having to change this all the time when I want to run more than 1 project at the same time. Lets make that easier!
