### PR TITLE
fix(app): Remove redundant bootstrap-sass import

### DIFF
--- a/app/templates/styles/main.scss
+++ b/app/templates/styles/main.scss
@@ -1,7 +1,5 @@
 <% if (compassBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
 
-@import 'bootstrap-sass-official/vendor/assets/stylesheets/bootstrap';
-
 <% } %>// bower:scss
 // endbower
 


### PR DESCRIPTION
This line is redundant cause `bowerInstall` adds this line automatically.
