### PR TITLE
fix(Gruntfile): fix usemin bug when using images in css

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -263,7 +263,7 @@ module.exports = function (grunt) {
       html: ['<%%= yeoman.dist %>/{,*/}*.html'],
       css: ['<%%= yeoman.dist %>/styles/{,*/}*.css'],
       options: {
-        assetsDirs: ['<%%= yeoman.dist %>']
+        assetsDirs: ['<%%= yeoman.dist %>','<%%= yeoman.dist %>/images']
       }
     },
 


### PR DESCRIPTION
Fix the bug that occurs when using images in css file. 
Referring this issue https://github.com/yeoman/grunt-usemin/issues/235
