### PR TITLE
feat(app): change appPath to accept option

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -26,7 +26,9 @@ var Generator = module.exports = function Generator(args, options) {
     try {
       this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
     } catch (e) {}
-    this.env.options.appPath = this.env.options.appPath || 'app';
+    if(!this.env.options.appPath) {
+      this.env.options.appPath = this.options.appPath || 'app';
+    }
   }
 
   this.appPath = this.env.options.appPath;

--- a/script-base.js
+++ b/script-base.js
@@ -22,7 +22,9 @@ var Generator = module.exports = function Generator() {
     try {
       this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
     } catch (e) {}
-    this.env.options.appPath = this.env.options.appPath || 'app';
+    if(!this.env.options.appPath) {
+      this.env.options.appPath = this.options.appPath || 'app';
+    }
   }
 
   if (typeof this.env.options.testPath === 'undefined') {

--- a/view/index.js
+++ b/view/index.js
@@ -12,7 +12,9 @@ var Generator = module.exports = function Generator() {
     try {
       this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
     } catch (e) {}
-    this.env.options.appPath = this.env.options.appPath || 'app';
+    if(!this.env.options.appPath) {
+      this.env.options.appPath = this.options.appPath || 'app';
+    }
   }
 };
 


### PR DESCRIPTION
Change `appPath` variable to accept option passed to generator. Allow
for custom appPath to be specified at runtime using option rather than
having to change the environment variable or bower.json file.
