### PR TITLE
fix (templates): change livereload:true to connect.options.livereload

### DIFF
--- a/templates/common/Gruntfile.js
+++ b/templates/common/Gruntfile.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
         files: ['<%%= yeoman.app %>/scripts/{,*/}*.js'],
         tasks: ['newer:jshint:all'],
         options: {
-          livereload: true
+          livereload: '<%%= connect.options.livereload %>'
         }
       },
       jsTest: {


### PR DESCRIPTION
The "livereload: true" uses the default port 35729. When wanting to change the default port in
connect.options.livereload, say because you simultaneously have several projects opened at
the same time, this results in an error because the port is already in use.

Closes https://github.com/yeoman/generator-angular/issues/569
