### PR TITLE
feat(app): add a second route if ngRoute is chosen

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -94,6 +94,11 @@ var Generator = module.exports = function Generator(args, options) {
       }
     });
 
+    if (this.env.options.ngRoute) {
+      this.invoke('angular:route', {
+        args: ['about']
+      });
+    }
   });
 
   this.pkg = require('../package.json');

--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -20,11 +20,27 @@
     <![endif]-->
 
     <!-- Add your site or application content here -->
-    <% if (ngRoute) {
-      %><div class="container" ng-view></div><%
-    } else {
-      %><div class="container" ng-include="'views/main.html'" ng-controller="MainCtrl"></div><%
-    } %>
+    <div class="container">
+      <div class="header">
+        <ul class="nav nav-pills pull-right">
+          <li class="active"><a ng-href="#">Home</a></li>
+          <li><a ng-href="<% if (ngRoute) { %>#/about<% } else { %>#<% } %>">About</a></li>
+          <li><a ng-href="#">Contact</a></li>
+        </ul>
+        <h3 class="text-muted"><%= appname %></h3>
+      </div>
+
+      <% if (ngRoute) {
+        %><div ng-view></div><%
+      } else {
+        %><div ng-include="'views/main.html'" ng-controller="MainCtrl"></div><%
+      } %>
+
+      <div class="footer">
+        <p><span class="glyphicon glyphicon-heart"></span> from the Yeoman team</p>
+      </div>
+    </div>
+
 
     <!-- Google Analytics: change UA-XXXXX-X to be your site's ID -->
      <script>

--- a/templates/common/app/views/main.html
+++ b/templates/common/app/views/main.html
@@ -1,12 +1,3 @@
-<div class="header">
-  <ul class="nav nav-pills pull-right">
-    <li class="active"><a ng-href="#">Home</a></li>
-    <li><a ng-href="#">About</a></li>
-    <li><a ng-href="#">Contact</a></li>
-  </ul>
-  <h3 class="text-muted"><%= appname %></h3>
-</div>
-
 <div class="jumbotron">
   <h1>'Allo, 'Allo!</h1>
   <p class="lead">
@@ -29,8 +20,4 @@
 
   <h4>Karma</h4>
   <p>Spectacular Test Runner for JavaScript.</p>
-</div>
-
-<div class="footer">
-  <p><span class="glyphicon glyphicon-heart"></span> from the Yeoman team</p>
 </div>


### PR DESCRIPTION
This adds a second 'about' route if ngRoute is enabled. It also changes
around the layout to make the view replace the inner content instead of
the entire page as real world apps are more like this. Now the header
and footer are part of the app and only things between them change.
