### PR TITLE
Adding 2 dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "grunt-release": "~0.6.0",
     "load-grunt-tasks": "~0.3.0",
     "mocha": "*",
+    "karma-jasmine": "~0.1.5",
+    "karma-chrome-launcher": "~0.1.3",
     "semver": "~2.2.1",
     "underscore.string": "~2.3.1"
   },


### PR DESCRIPTION
'grunt test' doesn’t work out-of-the-box with the angular generator.  I
had to add these 2 dev dependences manually.

Is this the correct place to add the dev dependencies?
