### PR TITLE
gitignore - add .DS_Store and .idea

### DIFF
--- a/templates/common/root/gitignore
+++ b/templates/common/root/gitignore
@@ -3,3 +3,5 @@ dist
 .tmp
 .sass-cache
 app/bower_components
+.DS_Store
+.idea


### PR DESCRIPTION
.DS_Store - MacOS-related files
.idea - folder with project preferences from IntelliJ IDEA and descendants: WebStorm, PHPStorm, PyCharm, RubyMine.
