### PR TITLE
fix(index.html): wrap IE shim scripts in a grunt-usemin block

### DIFF
--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -54,8 +54,10 @@
     </script>
 
     <!--[if lt IE 9]>
+    <!-- build:js scripts/ieshimmer.js -->
     <script src="bower_components/es5-shim/es5-shim.js"></script>
     <script src="bower_components/json3/lib/json3.min.js"></script>
+    <!-- endbuild -->
     <![endif]-->
 
     <!-- build:js scripts/vendor.js -->


### PR DESCRIPTION
Added a build:js command around IE9 shim scripts. Without it, the compiled version (dist/index.html) will retain a reference to the 'bower_components' folder, which of course doesn't exist.
