### PR TITLE
Delete bowerrc

### DIFF
--- a/templates/common/root/_bowerrc
+++ b/templates/common/root/_bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "bower_components"
-}


### PR DESCRIPTION
Delete bowerrc because of all package contents are installed in the bower_components directory by default.
