### PR TITLE
fix(app): correct cssmin/concat build-tag paths

### DIFF
--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-    <!-- build:css styles/vendor.css -->
+    <!-- build:css(.) styles/vendor.css -->
     <!-- bower:css -->
     <!-- endbower -->
     <!-- endbuild -->
@@ -58,7 +58,7 @@
     <script src="bower_components/json3/lib/json3.min.js"></script>
     <![endif]-->
 
-    <!-- build:js scripts/vendor.js -->
+    <!-- build:js(.) scripts/vendor.js -->
     <!-- bower:js -->
     <!-- endbower -->
     <!-- endbuild -->


### PR DESCRIPTION
Since the `bower_componets` got moved to root directory, vendor.css/.js are not created in `dist`.

This should fix it. Also fixes the ie8 shims.
