### PR TITLE
Update uglify.js options for vendor.js in useminPrepare

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -268,7 +268,19 @@ module.exports = function (grunt) {
               js: ['concat', 'uglifyjs'],
               css: ['cssmin']
             },
-            post: {}
+            post: {
+              js:[{
+                name: 'uglifyjs',
+                createConfig: function (context, block) {
+                  if (block.dest === 'scripts/vendor.js'){
+                    block.options = {
+                      mangle: false,
+                      preserveComments: 'some'
+                    };
+                  }
+                }
+              }]
+            }
           }
         }
       }


### PR DESCRIPTION
This adds a simple useminPrepare post processor to update the uglifyjs options for `script/vendor.js`. This should make for a much better developer experience when working with javascript vendor dependencies added via bower. Especially those which generate hard to debug errors in production builds because of generic uglifyjs options.

This addresses #701.
