### PR TITLE
Add internal link to route generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ Run `grunt` for building and `grunt serve` for preview
 Available generators:
 
 * [angular](#app) (aka [angular:app](#app))
+* [angular:route](#route)
 * [angular:controller](#controller)
 * [angular:directive](#directive)
 * [angular:filter](#filter)


### PR DESCRIPTION
Why not link the routes section? On the one hand the table is long enough so it's indicated to link that section, on the other hand it's confusing to exclude a section from the table.
