### PR TITLE
Fix provider coffee template

### DIFF
--- a/templates/coffeescript/service/provider.coffee
+++ b/templates/coffeescript/service/provider.coffee
@@ -8,7 +8,7 @@
  # Provider in the <%= scriptAppName %>.
 ###
 angular.module('<%= scriptAppName %>')
-  .provider '<%= cameledName %>', [->
+  .provider '<%= cameledName %>', ->
 
     # Private variables
     salutation = 'Hello'
@@ -25,4 +25,5 @@ angular.module('<%= scriptAppName %>')
     # Method for instantiating
     @$get = ->
       new Greeter()
-  ]
+      
+    return


### PR DESCRIPTION
Removed unnecessary array syntax and added an explicit return to ensure nothing is implicitly returned. Without this change Angular complains since the return value ends up being the `$get` function.
