### PR TITLE
make sure the es5-shim and json3 scripts get packaged

### DIFF
--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -54,8 +54,10 @@
     </script>
 
     <!--[if lt IE 9]>
+    <!-- build:js(.) scripts/ie8-compat.js -->
     <script src="bower_components/es5-shim/es5-shim.js"></script>
     <script src="bower_components/json3/lib/json3.min.js"></script>
+    <!-- endbuild -->
     <![endif]-->
 
     <!-- build:js(.) scripts/vendor.js -->


### PR DESCRIPTION
When doing a 'grunt build' the IE < 9 compatibility libraries don't get packaged. This addresses this 'issue'
