### PR TITLE
UPDATE bootstrap font path

### DIFF
--- a/templates/common/app/styles/main.scss
+++ b/templates/common/app/styles/main.scss
@@ -1,4 +1,4 @@
-<% if (compassBootstrap) { %>$icon-font-path: "../bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
+<% if (compassBootstrap) { %>$icon-font-path: "../bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
 <% } %>// bower:scss
 // endbower
 


### PR DESCRIPTION
The path to fonts inside bootstrap (SASS)  have a wrong path.
Bootstrap: 3.2.0
