### PR TITLE
fix(wiredep): exclude json3.js from wiredep

### DIFF
--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -56,7 +56,7 @@
     <!-- build:js(.) scripts/oldieshim.js -->
     <!--[if lt IE 9]>
     <script src="bower_components/es5-shim/es5-shim.js"></script>
-    <script src="bower_components/json3/lib/json3.min.js"></script>
+    <script src="bower_components/json3/lib/json3.js"></script>
     <![endif]-->
     <!-- endbuild -->
 


### PR DESCRIPTION
json3.js is already in the block scripts/oldieshim.js so it should not be injected by wiredep
