### PR TITLE
fix(wiredep): remove cwd property

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -175,9 +175,6 @@ module.exports = function (grunt) {
 
     // Automatically inject Bower components into the app
     wiredep: {
-      options: {
-        cwd: '<%%= yeoman.app %>'
-      },
       app: {
         src: ['<%%= yeoman.app %>/index.html'],
         ignorePath:  /\.\.\//


### PR DESCRIPTION
Before yesterday, grunt-wiredep wasn't actually supporting options objects. Now that it is, and since this setting is incorrect, it's throwing an error.

https://github.com/stephenplusplus/grunt-wiredep/issues/100#issuecomment-54745940

// @eddiemonge merge + release would be great :+1: 
