### PR TITLE
Adds chalk dependency to package.json template.

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -27,7 +27,8 @@
     "grunt-wiredep": "^1.7.0",
     "jshint-stylish": "^0.2.0",
     "load-grunt-tasks": "^0.4.0",
-    "time-grunt": "^0.3.1"
+    "time-grunt": "^0.3.1",
+    "chalk": "^0.5.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Solves part of the issue #841. The other part (Gruntfile.js wiredep cwd) is already solved in another pull request (#842).
