### PR TITLE
.git contents are deleted on 'clean'

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -151,7 +151,7 @@ module.exports = function (grunt) {
           src: [
             '.tmp',
             '<%%= yeoman.dist %>/{,*/}*',
-            '!<%%= yeoman.dist %>/.git*'
+            '!<%%= yeoman.dist %>/.git/**'
           ]
         }]
       },


### PR DESCRIPTION
When 'clean' is run when doing a `grunt build` it will delete the contents of the `dist/.git` folder.  I don't think this was intended.  Modifying the Gruntfile, to ensure that the `dist/.git` contents are preserved.
