### PR TITLE
feat(karma): wiredep karma configuration

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -70,46 +70,16 @@ var Generator = module.exports = function Generator(args, options) {
   });
 
   this.on('end', function () {
-    var enabledComponents = [];
-
-    if (this.animateModule) {
-      enabledComponents.push('angular-animate/angular-animate.js');
-    }
-
-    if (this.ariaModule) {
-      enabledComponents.push('angular-aria/angular-aria.js');
-    }
-
-    if (this.cookiesModule) {
-      enabledComponents.push('angular-cookies/angular-cookies.js');
-    }
-
-    if (this.messagesModule) {
-      enabledComponents.push('angular-messages/angular-messages.js');
-    }
-
-    if (this.resourceModule) {
-      enabledComponents.push('angular-resource/angular-resource.js');
-    }
-
-    if (this.routeModule) {
-      enabledComponents.push('angular-route/angular-route.js');
-    }
-
-    if (this.sanitizeModule) {
-      enabledComponents.push('angular-sanitize/angular-sanitize.js');
-    }
-
-    if (this.touchModule) {
-      enabledComponents.push('angular-touch/angular-touch.js');
-    }
-
-    enabledComponents = [
-      'angular/angular.js',
-      'angular-mocks/angular-mocks.js'
-    ].concat(enabledComponents).join(',');
-
     var jsExt = this.options.coffee ? 'coffee' : 'js';
+
+    var bowerComments = [
+      'bower:js',
+      'endbower'
+    ];
+    if (this.options.coffee) {
+      bowerComments.push('bower:coffee');
+      bowerComments.push('endbower');
+    }
 
     this.invoke('karma:app', {
       options: {
@@ -117,7 +87,7 @@ var Generator = module.exports = function Generator(args, options) {
         'base-path': '../',
         'coffee': this.options.coffee,
         'travis': true,
-        'bower-components': enabledComponents,
+        'files-comments': bowerComments.join(','),
         'app-files': 'app/scripts/**/*.' + jsExt,
         'test-files': [
           'test/mock/**/*.' + jsExt,
@@ -349,18 +319,6 @@ Generator.prototype._injectDependencies = function _injectDependencies() {
       '\n' + chalk.yellow.bold('grunt wiredep')
     );
   } else {
-    wiredep({
-      directory: 'bower_components',
-      bowerJson: JSON.parse(fs.readFileSync('./bower.json')),
-      ignorePath: new RegExp('^(' + this.appPath + '|..)/'),
-      src: 'app/index.html',
-      fileTypes: {
-        html: {
-          replace: {
-            css: '<link rel="stylesheet" href="{{filePath}}">'
-          }
-        }
-      }
-    });
+    this.spawnCommand('grunt', ['wiredep']);
   }
 };

--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -178,6 +178,33 @@ module.exports = function (grunt) {
       app: {
         src: ['<%%= yeoman.app %>/index.html'],
         ignorePath:  /\.\.\//
+      },
+      test: {
+        devDependencies: true,
+        src: '<%%= karma.unit.configFile %>',
+        ignorePath:  /\.\.\//,
+        fileTypes:{<% if (coffee) { %>
+          coffee: {
+            block: /(([\s\t]*)#\s*?bower:\s*?(\S*))(\n|\r|.)*?(#\s*endbower)/gi,
+              detect: {
+                js: /'(.*\.js)'/gi,
+                coffee: /'(.*\.coffee)'/gi
+              },
+            replace: {
+              js: '\'{{filePath}}\'',
+              coffee: '\'{{filePath}}\''
+            }
+          }<% } else { %>
+          js: {
+            block: /(([\s\t]*)\/{2}\s*?bower:\s*?(\S*))(\n|\r|.)*?(\/{2}\s*endbower)/gi,
+              detect: {
+                js: /'(.*\.js)'/gi
+              },
+              replace: {
+                js: '\'{{filePath}}\','
+              }
+            }<% } %>
+          }
       }<% if (compass) { %>,
       sass: {
         src: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
@@ -465,6 +492,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test', [
     'clean:server',
+    'wiredep:test',
     'concurrent:test',
     'autoprefixer',
     'connect:test',


### PR DESCRIPTION
Update Gruntfile and generated karma configuration for wiredep to wire bower dependencies and devDependencies into karma configuration.

This also replace manual wiredep call of installDependencies callback by an invocation of grunt wiredep using spawnCommand, avoiding duplicated code.

Fixes #856