### PR TITLE
chore(deps): update grunt-ng-annotate

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -21,7 +21,7 @@
     "grunt-filerev": "^0.2.1",
     "grunt-google-cdn": "^0.4.0",
     "grunt-newer": "^0.7.0",
-    "grunt-ng-annotate": "^0.3.0",
+    "grunt-ng-annotate": "^0.4.0",
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "^1.7.0",


### PR DESCRIPTION
Update grunt-ng-annotate to 0.4.0 to get ng-annotate 0.10 which provides
notable improvements.

Closes #861
