### PR TITLE
chore(bowerrc): Avoid hardcoding path of bower components

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -18,7 +18,8 @@ module.exports = function (grunt) {
   // Configurable paths for the application
   var appConfig = {
     app: require('./bower.json').appPath || 'app',
-    dist: 'dist'
+    dist: 'dist',
+    vendor: ((grunt.file.exists('./.bowerrc')) ? grunt.file.readJSON('./.bowerrc').directory : 'bower_components') || 'bower_components'
   };
 
   // Define the configuration for all the tasks
@@ -91,8 +92,8 @@ module.exports = function (grunt) {
             return [
               connect.static('.tmp'),
               connect().use(
-                '/bower_components',
-                connect.static('./bower_components')
+                '<%%= yeoman.vendor %>',
+                connect.static('<%%= yeoman.vendor %>')
               ),
               connect.static(appConfig.app)
             ];
@@ -107,8 +108,8 @@ module.exports = function (grunt) {
               connect.static('.tmp'),
               connect.static('test'),
               connect().use(
-                '/bower_components',
-                connect.static('./bower_components')
+                '<%%= yeoman.vendor %>',
+                connect.static('<%%= yeoman.vendor %>')
               ),
               connect.static(appConfig.app)
             ];
@@ -181,7 +182,7 @@ module.exports = function (grunt) {
       }<% if (compass) { %>,
       sass: {
         src: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
-        ignorePath: /(\.\.\/){1,2}bower_components\//
+        ignorePath: /(\.\.\/){1,2}<%%= yeoman.vendor %>\//
       }<% } %>
     },<% if (coffee) { %>
 
@@ -220,7 +221,7 @@ module.exports = function (grunt) {
         imagesDir: '<%%= yeoman.app %>/images',
         javascriptsDir: '<%%= yeoman.app %>/scripts',
         fontsDir: '<%%= yeoman.app %>/styles/fonts',
-        importPath: './bower_components',
+        importPath: '<%%= yeoman.vendor %>',
         httpImagesPath: '/images',
         httpGeneratedImagesPath: '/images/generated',
         httpFontsPath: '/styles/fonts',
@@ -390,12 +391,12 @@ module.exports = function (grunt) {
         }<% if (bootstrap) { %>, {
           expand: true,
           cwd: '<% if (!compassBootstrap) {
-              %>bower_components/bootstrap/dist<%
+              %><%%= yeoman.vendor %>/bootstrap/dist<%
             } else {
               %>.<%
             } %>',
           src: '<% if (compassBootstrap) {
-              %>bower_components/bootstrap-sass-official/assets/fonts/bootstrap<%
+              %><%%= yeoman.vendor %>/bootstrap-sass-official/assets/fonts/bootstrap<%
             } else { %>fonts<% }
             %>/*',
           dest: '<%%= yeoman.dist %>'


### PR DESCRIPTION
As we may define specific path for bower components in a `.bowerrc` file, we may look for such a file and use this value if it is provided.
If there is no `.bowerrc` file or no `directory` property defined, the default value is "bower_component_".
