### PR TITLE
npm WARN package.json No repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "script-base.js",
     "util.js"
   ],
-  "repository": "yeoman/generator-angular",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/yeoman/generator-angular.git"
+  }
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
When I do `yo angular` I get the below warnings:

npm WARN package.json todo@0.0.0 No repository field.
npm WARN package.json todo@0.0.0 No README data.

Searching on internet I found that it can be avoided by having a README.md file and the second warning can be avoided by using "repository" attribute in "package.json" but we already have "repository" attribute, maybe it requires an absolute URL? Please test!
