### PR TITLE
fixed a bug in provider coffeescript template

### DIFF
--- a/templates/coffeescript/service/provider.coffee
+++ b/templates/coffeescript/service/provider.coffee
@@ -15,8 +15,9 @@ angular.module('<%= scriptAppName %>')
 
     # Private constructor
     class Greeter
-      @greet = ->
-        salutation
+      constructor: ->
+        @greet = () ->
+          salutation
 
     # Public API for configuration
     @setSalutation = (s) ->


### PR DESCRIPTION
previous version generated Greeter.greet = function(){}, right now all is ok
