### PR TITLE
fix(build): do not clean git related subfolders of dist

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -151,7 +151,7 @@ module.exports = function (grunt) {
           src: [
             '.tmp',
             '<%%= yeoman.dist %>/{,*/}*',
-            '!<%%= yeoman.dist %>/.git*'
+            '!<%%= yeoman.dist %>/.git{,*/}*'
           ]
         }]
       },


### PR DESCRIPTION
clean scope was updated in 9db87bf6f61252db604e9ae4e9b13360f8b96eef, but
the scope of excluded git related files was not updated accordingly.
This caused clean to keep only the .git folder, but none of its contents.
I am not sure if this was caused by a change in node-glob, but it does
not work as expected.

I discovered this issue when using grunt-build-control, which will check
for the existence of a .git subfolder in dist and assume a repo exists
if such a folder exists (that check could probably be made more robust).

Unfortunately, I have not been able to find a good way to write a test
for this scenario. If someone has pointers on how to effectively write
tests that actually run grunt tasks based on the _Gruntfile.js template, 
I would be happy to give it a shot.
