### PR TITLE
fix(build): allow to copy font files from subfolders

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -380,7 +380,7 @@ module.exports = function (grunt) {
             '*.html',
             'views/{,*/}*.html',
             'images/{,*/}*.{webp}',
-            'fonts/*'
+            'fonts/{,*/}*.*'
           ]
         }, {
           expand: true,


### PR DESCRIPTION
Give the possibility to store fonts as I want, not how you.
Change allows you to catalog fonts.
