### PR TITLE
chore(docs): add correct --appPath option description

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -26,7 +26,7 @@ var Generator = module.exports = function Generator(args, options) {
 
   if (typeof this.env.options.appPath === 'undefined') {
     this.option('appPath', {
-      desc: 'Generate CoffeeScript instead of JavaScript'
+      desc: 'Allow to choose where to write the files'
     });
 
     this.env.options.appPath = this.options.appPath;


### PR DESCRIPTION
This PR brings description of --appPath option missing from the
d3dd42e3 original commit and is a very trivial PR. The reasoning behind this PR is that `--help` option for generator prints outs misleading description of two different options:

``` bash
yo angular --help
```

``` bash
--appPath             # Generate CoffeeScript instead of JavaScript ...
--coffee              # Generate CoffeeScript instead of JavaScript ...
```

After this change the `--help` option will correctly print option purpose:

``` bash
--appPath             # Allow to choose where to write the files ...
--coffee              # Generate CoffeeScript instead of JavaScript ...
```

I've signed CLA on code.google.com already under my github.com username.
