### PR TITLE
Adding forward slashes to menu item routes to avoid blink effect on route changes

### DIFF
--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -23,9 +23,9 @@
     <div class="container">
       <div class="header">
         <ul class="nav nav-pills pull-right">
-          <li class="active"><a ng-href="#">Home</a></li>
-          <li><a ng-href="<% if (ngRoute) { %>#/about<% } else { %>#<% } %>">About</a></li>
-          <li><a ng-href="#">Contact</a></li>
+          <li class="active"><a ng-href="#/">Home</a></li>
+          <li><a ng-href="<% if (ngRoute) { %>#/about<% } else { %>#/<% } %>">About</a></li>
+          <li><a ng-href="#/">Contact</a></li>
         </ul>
         <h3 class="text-muted"><%= appname %></h3>
       </div>

--- a/templates/common/app/views/main.html
+++ b/templates/common/app/views/main.html
@@ -4,7 +4,7 @@
     <img src="images/yeoman.png" alt="I'm Yeoman"><br>
     Always a pleasure scaffolding your apps.
   </p>
-  <p><a class="btn btn-lg btn-success" ng-href="#">Splendid!<span class="glyphicon glyphicon-ok"></span></a></p>
+  <p><a class="btn btn-lg btn-success" ng-href="#/">Splendid!<span class="glyphicon glyphicon-ok"></span></a></p>
 </div>
 
 <div class="row marketing">


### PR DESCRIPTION
When Yeoman's scaffolding process for a new AngularJS finishes you'll have an app that blinks when you click on any menu item. To see the effect happening, try to scaffold a new app and click on About and them Home menu items. You'll see the screen blinking.

The browser is understanding the action as a whole new HTTP request, I'm not sure why, but changing the Home route to `#/` avoid the annoying effect.
