### PR TITLE
Use caret instead of tilde for dev deps

### DIFF
--- a/templates/common/root/_bower.json
+++ b/templates/common/root/_bower.json
@@ -17,8 +17,8 @@
     "angular-touch": "^<%= ngVer %>"<% } %>
   },
   "devDependencies": {
-    "angular-mocks": "~<%= ngVer %>",
-    "angular-scenario": "~<%= ngVer %>"
+    "angular-mocks": "^<%= ngVer %>",
+    "angular-scenario": "^<%= ngVer %>"
   }<% if (appPath) { %>,
   "appPath": "<%= appPath %>"<% } %>
 }


### PR DESCRIPTION
this makes it to be consistent with dev deps and to match the angular version
