### PR TITLE
chore(docs): update readme with --appPath option usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,11 @@ You can change the `app` directory by adding a `appPath` property to `bower.json
 ```
 This will cause Yeoman-generated client-side files to be placed in `public`.
 
+Note that you can also achieve the same results by adding an `--appPath` option when starting generator:
+```bash
+yo angular [app-name] --appPath=public
+```
+
 ## Testing
 
 Running `grunt test` will run the unit tests with karma.


### PR DESCRIPTION
This trivial PR intends to complete documentation section for application output configuration with added example use of `--appPath` option. 
When used in non-intended way `--appPath` can lead to cryptic errors that do not explain reason of generator error.
For details please see: https://github.com/yeoman/generator-angular/issues/926
Generator v. 0.10.0
![screen shot 2014-11-15 at 00 39 09](https://cloud.githubusercontent.com/assets/14539/5055215/6aedebe0-6c60-11e4-9419-4bd792daa770.png)
