### PR TITLE
chore(compass): use sourcemap instead of debugInfo

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -235,7 +235,7 @@ module.exports = function (grunt) {
       },
       server: {
         options: {
-          debugInfo: true
+          sourcemap: true
         }
       }
     },<% } %>


### PR DESCRIPTION
debugInfo is useless without browser addon. firesass-for-firebug is unpublished and https://addons.mozilla.org/en-US/firefox/addon/firecompass-for-firebug/ is only for firefox