### PR TITLE
copy:dist fonts and ensure revs update

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -276,7 +276,11 @@ module.exports = function (grunt) {
       html: ['<%%= yeoman.dist %>/{,*/}*.html'],
       css: ['<%%= yeoman.dist %>/styles/{,*/}*.css'],
       options: {
-        assetsDirs: ['<%%= yeoman.dist %>','<%%= yeoman.dist %>/images']
+        assetsDirs: [
+          '<%%= yeoman.dist %>',
+          '<%%= yeoman.dist %>/images',
+          '<%%= yeoman.dist %>/styles'
+        ]
       }
     },
 
@@ -380,7 +384,7 @@ module.exports = function (grunt) {
             '*.html',
             'views/{,*/}*.html',
             'images/{,*/}*.{webp}',
-            'fonts/{,*/}*.*'
+            'styles/fonts/{,*/}*.*'
           ]
         }, {
           expand: true,


### PR DESCRIPTION
Fonts were not being copied for builds since the fonts dir was moved to `/styles/fonts`. Updated the path in the `copy:dist` task.

Not 100% sure how the `usemin` task works, but without `/styles` in the `assetsDirs`, it wasn't updating the references to the reved fonts.
