### PR TITLE
404.html: use lowercase doctype

### DIFF
--- a/templates/common/app/404.html
+++ b/templates/common/app/404.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
In other files we use a lowercased doctype: https://github.com/yeoman/generator-angular/blob/8416c549a24eb30cd7f9763682d81bb8718c1681/templates/common/app/index.html#L1, so this was kinda inconsistent.