### PR TITLE
feat(app): read module name form bower.json

### DIFF
--- a/script-base.js
+++ b/script-base.js
@@ -8,40 +8,31 @@ var chalk = require('chalk');
 var Generator = module.exports = function Generator() {
   yeoman.generators.NamedBase.apply(this, arguments);
 
-  try {
-    this.appname = require(path.join(process.cwd(), 'bower.json')).name;
-  } catch (e) {
-    this.appname = path.basename(process.cwd());
-  }
-  this.appname = this._.slugify(this._.humanize(this.appname));
+  var bowerJson = {};
 
   try {
-    this.scriptAppName = require(path.join(process.cwd(), 'bower.json')).moduleName;
+    bowerJson = require(path.join(process.cwd(), 'bower.json'));
   } catch (e) {}
 
-  this.scriptAppName = this.scriptAppName || this._.camelize(this.appname) + angularUtils.appName(this);
+  if (bowerJson.name) {
+    this.appname = bowerJson.name;
+  } else {
+    this.appname = path.basename(process.cwd());
+  }
+
+  this.appname = this._.slugify(this._.humanize(this.appname));
+
+  this.scriptAppName = bowerJson.moduleName || this._.camelize(this.appname) + angularUtils.appName(this);
 
   this.cameledName = this._.camelize(this.name);
   this.classedName = this._.classify(this.name);
 
   if (typeof this.env.options.appPath === 'undefined') {
-    this.env.options.appPath = this.options.appPath;
-
-    if (!this.env.options.appPath) {
-      try {
-        this.env.options.appPath = require(path.join(process.cwd(), 'bower.json')).appPath;
-      } catch (e) {}
-    }
-    this.env.options.appPath = this.env.options.appPath || 'app';
+    this.env.options.appPath = this.options.appPath || bowerJson.appPath || 'app';
     this.options.appPath = this.env.options.appPath;
   }
 
-  if (typeof this.env.options.testPath === 'undefined') {
-    try {
-      this.env.options.testPath = require(path.join(process.cwd(), 'bower.json')).testPath;
-    } catch (e) {}
-    this.env.options.testPath = this.env.options.testPath || 'test/spec';
-  }
+  this.env.options.testPath = this.env.options.testPath || bowerJson.testPath || 'test/spec';
 
   this.env.options.coffee = this.options.coffee;
   if (typeof this.env.options.coffee === 'undefined') {

--- a/script-base.js
+++ b/script-base.js
@@ -14,7 +14,12 @@ var Generator = module.exports = function Generator() {
     this.appname = path.basename(process.cwd());
   }
   this.appname = this._.slugify(this._.humanize(this.appname));
-  this.scriptAppName = this._.camelize(this.appname) + angularUtils.appName(this);
+
+  try {
+    this.scriptAppName = require(path.join(process.cwd(), 'bower.json')).moduleName;
+  } catch (e) {}
+
+  this.scriptAppName = this.scriptAppName || this._.camelize(this.appname) + angularUtils.appName(this);
 
   this.cameledName = this._.camelize(this.name);
   this.classedName = this._.classify(this.name);

--- a/templates/common/root/_bower.json
+++ b/templates/common/root/_bower.json
@@ -17,5 +17,6 @@
   "devDependencies": {
     "angular-mocks": "^<%= ngVer %>"
   }<% if (appPath) { %>,
-  "appPath": "<%= appPath %>"<% } %>
+  "appPath": "<%= appPath %>"<% } %>,
+  "moduleName": "<%= scriptAppName %>"
 }


### PR DESCRIPTION
app-suffix option is not saved for later uses and needs to be readded to each
future subgenerator. This change reads module name from new bower.json field
so module author have full flexibility about naming it.