### PR TITLE
fix(karma): compass and autoprefixer need wiredep:sass for test task

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -496,7 +496,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test', [
     'clean:server',
-    'wiredep:test',
+    'wiredep',
     'concurrent:test',
     'autoprefixer',
     'connect:test',


### PR DESCRIPTION
Unless we remove all css related tasks from 'test' task as I don't think current build can test css