### PR TITLE
bc not *every* machine has karma

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -27,6 +27,7 @@
     "grunt-usemin": "^2.6.2",
     "grunt-wiredep": "^2.0.0",
     "jshint-stylish": "^1.0.0",
+    "karma": "^0.12",
     "load-grunt-tasks": "^1.0.0",
     "time-grunt": "^1.0.0"
   },


### PR DESCRIPTION
Putting aside our rejoicing in how mighty it is and how we ought already have it globally installed, [Karma](https://www.npmjs.com/package/karma) is a dev dep, right?

Gruntfile.js as-is causes the base yeoman scaffold to fail `grunt` with `Warning: Task "karma" not found. Use --force to continue.`