### PR TITLE
fix(app): update grunt-ng-annotate

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -22,7 +22,7 @@
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",
     "grunt-newer": "^0.8.0",
-    "grunt-ng-annotate": "^0.8.0",
+    "grunt-ng-annotate": "^0.9.0",
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^2.6.2",
     "grunt-wiredep": "^2.0.0",


### PR DESCRIPTION
Re pull-request #1004 

generator-angular cannot run with node@0.12. Fail ngAnnotate:dist task.

$ node -v
v0.12.0
$ npm -v
2.5.1
$ mkdir angular1 && cd $_
$ yo angular
...
$ grunt
...
Running "ngAnnotate:dist" (ngAnnotate) task
Warning: Cannot assign to read only property '$methodName' of false Use --force to continue.

Aborted due to warnings.
...

grunt-ng-annotate and ng-annotate too old.