### PR TITLE
feat(templates): add provider test scafolding

### DIFF
--- a/provider/index.js
+++ b/provider/index.js
@@ -12,7 +12,7 @@ util.inherits(Generator, ScriptBase);
 Generator.prototype.createServiceFiles = function createServiceFiles() {
   this.generateSourceAndTest(
     'service/provider',
-    'spec/service',
+    'spec/provider',
     'services',
     this.options['skip-add'] || false
   );

--- a/templates/coffeescript/spec/provider.coffee
+++ b/templates/coffeescript/spec/provider.coffee
@@ -1,0 +1,30 @@
+'use strict'
+
+describe 'Service: <%= cameledName %>', ->
+
+  # instantiate service
+  <%= cameledName %> = {}
+  init = ->
+    inject (_<%= cameledName %>_) ->
+      <%= cameledName %> = _<%= cameledName %>_
+      return
+    return
+
+  # load the service's module
+  beforeEach module '<%= scriptAppName %>'
+
+  it 'should do something', ->
+    init()
+    expect(!!<%= cameledName %>).toBe true
+    return
+
+  it 'should be configurable', ->
+    module (<%= cameledName %>Provider) ->
+      <%= cameledName %>Provider.setSalutation 'Lorem ipsum'
+      return
+
+    init()
+
+    expect(<%= cameledName %>.greet()).toEqual 'Lorem ipsum'
+    return
+  return

--- a/templates/javascript/spec/provider.js
+++ b/templates/javascript/spec/provider.js
@@ -1,0 +1,32 @@
+'use strict';
+
+describe('Service: <%= cameledName %>', function () {
+
+  // instantiate service
+  var <%= cameledName %>,
+    init = function () {
+      inject(function (_<%= cameledName %>_) {
+        <%= cameledName %> = _<%= cameledName %>_;
+      });
+    };
+
+  // load the service's module
+  beforeEach(module('<%= scriptAppName %>'));
+
+  it('should do something', function () {
+    init();
+
+    expect(!!<%= cameledName %>).toBe(true);
+  });
+
+  it('should be configurable', function () {
+    module(function (<%= cameledName %>Provider) {
+      <%= cameledName %>Provider.setSalutation('Lorem ipsum');
+    });
+
+    init();
+
+    expect(<%= cameledName %>.greet()).toEqual('Lorem ipsum');
+  });
+
+});


### PR DESCRIPTION
WIP. A separate template for testing providers. Allows users to start quicker testing providers without searching the way to access serviceProvider from test file.