### PR TITLE
docs(readme) + X-UA-Compatible in index.html

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Run `yo angular`, optionally passing an app name:
 yo angular [app-name]
 ```
 
-Run `grunt` for building and `grunt serve` for preview
+Run `grunt` for building and `grunt serve` for dev preview or `grunt serve:dist` for prod-ready preview.
 
 
 ## Generators

--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title></title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->


### PR DESCRIPTION
- add info about serve in prod mode as there was no info about `grunt serve:dist` anywhere and it was not trivial to guess
- add **X-UA-Compatible** meta tag to index.html template to avoid random choosing lower version of IE engine by the IE itself