### PR TITLE
Updated grunt-ng-annotate to fix bug

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -22,7 +22,7 @@
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",
     "grunt-newer": "^1.1.0",
-    "grunt-ng-annotate": "^0.9.2",
+    "grunt-ng-annotate": "^0.10.0",
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
     "grunt-wiredep": "^2.0.0",


### PR DESCRIPTION
Bug: "error: Cannot assign to read only property '$methodName' of false Use --force to continue". When trying to do a build.

Detailed here: https://github.com/olov/ng-annotate/issues/139

Fix: Updated ng-annotate to 0.10.0

