### PR TITLE
fix(app): remove `no-js` class

### DIFF
--- a/templates/common/app/index.html
+++ b/templates/common/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js">
+<html>
   <head>
     <meta charset="utf-8">
     <title></title>


### PR DESCRIPTION
We don't have Modernizr, so this class should not be there. It never switches to `js`.