### PR TITLE
fix(app): Add `Disallow:` to robots.txt

### DIFF
--- a/templates/common/app/robots.txt
+++ b/templates/common/app/robots.txt
@@ -1,3 +1,4 @@
 # robotstxt.org
 
 User-agent: *
+Disallow:


### PR DESCRIPTION
The robots.txt standard:

> " The record starts with one or more User-agent lines, followed by one or
     more Disallow lines, as detailed below. "

Ref https://github.com/yeoman/generator-gulp-webapp/pull/220
      https://github.com/h5bp/html5-boilerplate/issues/1487
      http://www.robotstxt.org/orig.html