### PR TITLE
fix: add generator-angular and yo as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,10 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
+    "generator-karma": ">=0.9.0",
     "wiredep": "^2.2.0",
     "yeoman-generator": "^0.16.0",
     "yosay": "^1.0.2"
-  },
-  "peerDependencies": {
-    "generator-karma": ">=0.9.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
remove peerDependency warning for generator-angular

I noticed the following warning while installing this module.
```
npm WARN peerDependencies The peer dependency generator-karma included from generator-angular will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```