### PR TITLE
fix(ngtemplates): should build templateCache.js into .tmp

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -405,7 +405,7 @@ module.exports = function (grunt) {
         },
         cwd: '<%%= yeoman.app %>',
         src: 'views/{,*/}*.html',
-        dest: 'templateCache.js'
+        dest: '.tmp/templateCache.js'
       }
     },
 


### PR DESCRIPTION
Fixes https://github.com/yeoman/generator-angular/commit/b7b72b00330ba09594f148c3a87d047c69a1a15e