### PR TITLE
fix(gen): use absolute paths in generated .gitignore

### DIFF
--- a/templates/common/root/gitignore
+++ b/templates/common/root/gitignore
@@ -1,5 +1,5 @@
-node_modules
-dist
-.tmp
-.sass-cache
-bower_components
+/node_modules
+/dist
+/.tmp
+/.sass-cache
+/bower_components


### PR DESCRIPTION
The generated .gitignore contains relative paths that will match
in both the root of the project or somewhere down the tree.

This can be problematic if the project gets a folder called `dist`
or some other ignored name.

This patch makes the default .gitignores absolute.