### PR TITLE
fix(gen): switch ctrlAs name to a cameledName

### DIFF
--- a/route/index.js
+++ b/route/index.js
@@ -61,7 +61,7 @@ Generator.prototype.rewriteAppJs = function () {
     splicable: [
       "  templateUrl: 'views/" + this.name.toLowerCase() + ".html'" + (coffee ? "" : "," ),
       "  controller: '" + this.classedName + "Ctrl'" + (coffee ? "" : ","),
-      "  controllerAs: '" + this.classedName + "'"
+      "  controllerAs: '" + this.cameledName + "'"
     ]
   };
 


### PR DESCRIPTION
I think like the predefined `MainCtrl` the name in the `controllerAs` property should not forced to start with a capital.

https://github.com/yeoman/generator-angular/blob/master/templates/javascript/app.js#L18