### PR TITLE
Add a "name" field to _package.json package.

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -30,5 +30,6 @@
   },
   "engines": {
     "node": ">=0.10.0"
-  }
+  },
+  "name": "generator-angular generated application"
 }


### PR DESCRIPTION
Fix Issue #1099

Fixes failing tests by ensuring that Base.prototype.rootGeneratorName can find a name when used with package.json in the generated output.