### PR TITLE
Use lowercase package name without spaces

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -1,4 +1,5 @@
 {
+  "name": "<%= _.slugify(_.humanize(appname)) %>",
   "private": true,
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -30,6 +31,5 @@
   },
   "engines": {
     "node": ">=0.10.0"
-  },
-  "name": "generator-angular-generated-application"
+  }
 }

--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -31,5 +31,5 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "name": "generator-angular generated application"
+  "name": "generator-angular-generated-application"
 }


### PR DESCRIPTION
Fix Issue #1101 - having a space in a package name is invalid. The tests don't catch this but the generated package.json is invalid during use :-(