### PR TITLE
fix(htmlmin): disable the removeOptionalTags option.

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -384,8 +384,7 @@ module.exports = function (grunt) {
           collapseWhitespace: true,
           conservativeCollapse: true,
           collapseBooleanAttributes: true,
-          removeCommentsFromCDATA: true,
-          removeOptionalTags: true
+          removeCommentsFromCDATA: true
         },
         files: [{
           expand: true,


### PR DESCRIPTION
Enabling HTML minifier's `removeOptionalTags` option alongside libraries like the [AngularUI Router](https://github.com/angular-ui/ui-router#angularui-router-) causes iOS 8 devices to throw an ```TypeError: Attempted to assign to readonly property``` error. See screenshot [here](http://i.imgur.com/ID1Ynwt.jpg).

This obscure iOS8 ```TypeError` is a [known issue](https://github.com/angular/angular.js/issues/9128) in AngularJS, but on some cases, the fix is just to [disable removeOptionalTags](https://github.com/angular/angular.js/issues/9128#issuecomment-111648953) from `htmlmin`. As such, it shouldn't be enabled by default here.