### PR TITLE
fix(watch): sourcemap not updated on sass file change

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function (grunt) {
       },<% } %><% if (compass) { %>
       compass: {
         files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
-        tasks: ['compass:server', 'autoprefixer']
+        tasks: ['compass:server', 'autoprefixer:server']
       },<% } else { %>
       styles: {
         files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],


### PR DESCRIPTION
sourcemap doesn't update when SASS file changes because of autoprefixer:dist task running. Only autoprefixer:server task should run