### PR TITLE
Moved 'use strict'; to a functional scope inside js templates.

### DIFF
--- a/templates/javascript/app.js
+++ b/templates/javascript/app.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc overview
  * @name <%= scriptAppName %>
@@ -11,6 +9,8 @@
 angular
   .module('<%= scriptAppName %>', [<%= angularModules %>])<% if (ngRoute) { %>
   .config(function ($routeProvider) {
+    'use strict';
+
     $routeProvider
       .when('/', {
         templateUrl: 'views/main.html',

--- a/templates/javascript/controller.js
+++ b/templates/javascript/controller.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc function
  * @name <%= scriptAppName %>.controller:<%= classedName %>Ctrl
@@ -9,6 +7,8 @@
  */
 angular.module('<%= scriptAppName %>')
   .controller('<%= classedName %>Ctrl', function () {
+    'use strict';
+
     this.awesomeThings = [
       'HTML5 Boilerplate',
       'AngularJS',

--- a/templates/javascript/decorator.js
+++ b/templates/javascript/decorator.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc function
  * @name <%= scriptAppName %>.decorator:<%= classedName %>
@@ -9,6 +7,8 @@
  */
 angular.module('<%= scriptAppName %>')
   .config(function ($provide) {
+    'use strict';
+
     $provide.decorator('<%= cameledName %>', function ($delegate) {
       // decorate the $delegate
       return $delegate;

--- a/templates/javascript/directive.js
+++ b/templates/javascript/directive.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc directive
  * @name <%= scriptAppName %>.directive:<%= cameledName %>
@@ -8,6 +6,8 @@
  */
 angular.module('<%= scriptAppName %>')
   .directive('<%= cameledName %>', function () {
+    'use strict';
+
     return {
       template: '<div></div>',
       restrict: 'E',

--- a/templates/javascript/filter.js
+++ b/templates/javascript/filter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc filter
  * @name <%= scriptAppName %>.filter:<%= cameledName %>
@@ -10,6 +8,8 @@
  */
 angular.module('<%= scriptAppName %>')
   .filter('<%= cameledName %>', function () {
+    'use strict';
+
     return function (input) {
       return '<%= cameledName %> filter: ' + input;
     };

--- a/templates/javascript/service/factory.js
+++ b/templates/javascript/service/factory.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc service
  * @name <%= scriptAppName %>.<%= cameledName %>
@@ -9,6 +7,8 @@
  */
 angular.module('<%= scriptAppName %>')
   .factory('<%= cameledName %>', function () {
+    'use strict';
+
     // Service logic
     // ...
 

--- a/templates/javascript/service/provider.js
+++ b/templates/javascript/service/provider.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc service
  * @name <%= scriptAppName %>.<%= cameledName %>
@@ -9,6 +7,7 @@
  */
 angular.module('<%= scriptAppName %>')
   .provider('<%= cameledName %>', function () {
+    'use strict';
 
     // Private variables
     var salutation = 'Hello';

--- a/templates/javascript/service/service.js
+++ b/templates/javascript/service/service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * @ngdoc service
  * @name <%= scriptAppName %>.<%= cameledName %>
@@ -9,5 +7,7 @@
  */
 angular.module('<%= scriptAppName %>')
   .service('<%= cameledName %>', function () {
+    'use strict';
+
     // AngularJS will instantiate a singleton by calling "new" on this function
   });

--- a/templates/javascript/spec/controller.js
+++ b/templates/javascript/spec/controller.js
@@ -1,6 +1,5 @@
-'use strict';
-
 describe('Controller: <%= classedName %>Ctrl', function () {
+  'use strict';
 
   // load the controller's module
   beforeEach(module('<%= scriptAppName %>'));

--- a/templates/javascript/spec/directive.js
+++ b/templates/javascript/spec/directive.js
@@ -1,6 +1,5 @@
-'use strict';
-
 describe('Directive: <%= cameledName %>', function () {
+  'use strict';
 
   // load the directive's module
   beforeEach(module('<%= scriptAppName %>'));

--- a/templates/javascript/spec/filter.js
+++ b/templates/javascript/spec/filter.js
@@ -1,6 +1,5 @@
-'use strict';
-
 describe('Filter: <%= cameledName %>', function () {
+  'use strict';
 
   // load the filter's module
   beforeEach(module('<%= scriptAppName %>'));

--- a/templates/javascript/spec/provider.js
+++ b/templates/javascript/spec/provider.js
@@ -1,6 +1,5 @@
-'use strict';
-
 describe('Service: <%= cameledName %>', function () {
+  'use strict';
 
   // instantiate service
   var <%= cameledName %>,

--- a/templates/javascript/spec/service.js
+++ b/templates/javascript/spec/service.js
@@ -1,6 +1,5 @@
-'use strict';
-
 describe('Service: <%= cameledName %>', function () {
+  'use strict';
 
   // load the service's module
   beforeEach(module('<%= scriptAppName %>'));


### PR DESCRIPTION
By placing the 'use strict'; outside of a functional scope, it can force an entire application to be strict even if some 3rd party components are not. By moving this statement into each component's function, it forces that component into strict mode, without causing conflicts with non strict outside code. Besides, I found that placing it outside of the app functions didn't enforce strict anyway.