### PR TITLE
fix(app): create new $scope for controller tests

### DIFF
--- a/templates/coffeescript/spec/controller.coffee
+++ b/templates/coffeescript/spec/controller.coffee
@@ -7,8 +7,11 @@ describe 'Controller: <%= classedName %>Ctrl', ->
 
   <%= classedName %>Ctrl = {}
 
+  scope = {}
+
   # Initialize the controller and a mock scope
   beforeEach inject ($controller, $rootScope) ->
+    scope = $rootScope.$new()
     <%= classedName %>Ctrl = $controller '<%= classedName %>Ctrl', {
       # place here mocked dependencies
     }

--- a/templates/javascript/spec/controller.js
+++ b/templates/javascript/spec/controller.js
@@ -1,12 +1,12 @@
 'use strict';
 
 describe('Controller: <%= classedName %>Ctrl', function () {
-  var scope;
 
   // load the controller's module
   beforeEach(module('<%= scriptAppName %>'));
 
-  var <%= classedName %>Ctrl;
+  var <%= classedName %>Ctrl,
+    scope;
 
   // Initialize the controller and a mock scope
   beforeEach(inject(function ($controller, $rootScope) {

--- a/templates/javascript/spec/controller.js
+++ b/templates/javascript/spec/controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 describe('Controller: <%= classedName %>Ctrl', function () {
+  var scope;
 
   // load the controller's module
   beforeEach(module('<%= scriptAppName %>'));
@@ -9,7 +10,9 @@ describe('Controller: <%= classedName %>Ctrl', function () {
 
   // Initialize the controller and a mock scope
   beforeEach(inject(function ($controller, $rootScope) {
+    scope = $rootScope.$new();
     <%= classedName %>Ctrl = $controller('<%= classedName %>Ctrl', {
+      $scope: scope
       // place here mocked dependencies
     });
   }));


### PR DESCRIPTION
Creating new $scope for controller tests both is good practice and
prevents the grunt task failing on a clean install due to jshint
warnings.

Closes #1130