### PR TITLE
feat(gen): add jscs

### DIFF
--- a/common/index.js
+++ b/common/index.js
@@ -16,6 +16,9 @@ Generator.prototype.setupEnv = function setupEnv() {
   this.sourceRoot(join(__dirname, '../templates/common/root'));
   this.copy('.editorconfig');
   this.copy('.gitattributes');
+  if (!this.env.options.coffee) {
+    this.copy('.jscsrc');
+  }
   this.copy('.jshintrc');
   this.copy('.yo-rc.json');
   this.copy('gitignore', '.gitignore');

--- a/templates/common/root/.jscsrc
+++ b/templates/common/root/.jscsrc
@@ -1,0 +1,6 @@
+{
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+  "requireCapitalizedConstructors": true,
+  "requireParenthesesAroundIIFE": true,
+  "validateQuoteMarks": "'"
+}

--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -47,14 +47,14 @@ module.exports = function (grunt) {
       },<% } else { %>
       js: {
         files: ['<%%= yeoman.app %>/scripts/{,*/}*.js'],
-        tasks: ['newer:jshint:all'],
+        tasks: ['newer:jshint:all', 'newer:jscs:all'],
         options: {
           livereload: '<%%= connect.options.livereload %>'
         }
       },
       jsTest: {
         files: ['test/spec/{,*/}*.js'],
-        tasks: ['newer:jshint:test', 'karma']
+        tasks: ['newer:jshint:test', 'newer:jscs:test', 'karma']
       },<% } %><% if (compass) { %>
       compass: {
         files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
@@ -131,7 +131,7 @@ module.exports = function (grunt) {
       }
     },
 
-    // Make sure code styles are up to par and there are no obvious mistakes
+    // Make sure there are no obvious mistakes
     jshint: {
       options: {
         jshintrc: '.jshintrc',
@@ -151,7 +151,24 @@ module.exports = function (grunt) {
       }<% } %>
     },
 
-    // Empties folders to start fresh
+    <% if (!coffee) { %>// Make sure code styles are up to par
+    jscs: {
+      options: {
+        config: '.jscsrc',
+        verbose: true
+      },
+      all: {
+        src: [
+          'Gruntfile.js',
+          '<%%= yeoman.app %>/scripts/{,*/}*.js'
+        ]
+      },
+      test: {
+        src: ['test/spec/{,*/}*.js']
+      }
+    },
+
+    <% } %>// Empties folders to start fresh
     clean: {
       dist: {
         files: [{
@@ -556,7 +573,8 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('default', [
-    'newer:jshint',
+    'newer:jshint',<% if (!coffee) { %>
+    'newer:jscs',<% } %>
     'test',
     'build'
   ]);

--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -19,7 +19,8 @@
     "grunt-contrib-uglify": "^0.7.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-filerev": "^2.1.2",
-    "grunt-google-cdn": "^0.4.3",
+    "grunt-google-cdn": "^0.4.3",<% if (!coffee) { %>
+    "grunt-jscs": "^1.8.0",<% } %>
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
     "grunt-svgmin": "^2.0.0",

--- a/test/test-apppath.js
+++ b/test/test-apppath.js
@@ -71,6 +71,7 @@ describe('Angular generator appPath option', function () {
     it('creates expected JS files', function (done) {
       angular.run({}, function() {
         helpers.assertFile([].concat(expected, [
+          '.jscsrc',
           appPath + '/scripts/app.js',
           appPath + '/scripts/controllers/main.js',
           'test/spec/controllers/main.js'

--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -69,6 +69,7 @@ describe('Angular generator file creation', function () {
     it('creates expected JS files', function (done) {
       angular.run({}, function() {
         helpers.assertFile([].concat(expected, [
+          '.jscsrc',
           'app/scripts/app.js',
           'app/scripts/controllers/main.js',
           'test/spec/controllers/main.js'


### PR DESCRIPTION
Added jscs to replace styling rules deprecated by jshint. Details
can be found here regarding the rules that were previously used
by this generator: https://github.com/yeoman/generator-angular/pull/1086

Jscs rule descriptions can be found here: http://jscs.info/rules.html

Closes #1109