### PR TITLE
Upgrading grunt-autoprefixer to grunt-postcss to remove deprecation warnings

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -56,11 +56,11 @@ module.exports = function (grunt) {
       },<% } %><% if (compass) { %>
       compass: {
         files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
-        tasks: ['compass:server', 'autoprefixer']
+        tasks: ['compass:server', 'postcss']
       },<% } else { %>
       styles: {
         files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
-        tasks: ['newer:copy:styles', 'autoprefixer']
+        tasks: ['newer:copy:styles', 'postcss']
       },<% } %>
       gruntfile: {
         files: ['Gruntfile.js']
@@ -165,27 +165,29 @@ module.exports = function (grunt) {
     },
 
     // Add vendor prefixed styles
-    autoprefixer: {
+    postcss: {
       options: {
-        browsers: ['last 1 version']
+        processors: [
+          require('autoprefixer-core')({browsers: ['last 1 version']})
+        ]
       },
       server: {
         options: {
-          map: true,
+          map: true
         },
         files: [{
           expand: true,
-          cwd: '.tmp/styles/',
+          cwd: '.tmp/styles',
           src: '{,*/}*.css',
-          dest: '.tmp/styles/'
+          dest: '.tmp/styles'
         }]
       },
       dist: {
         files: [{
           expand: true,
-          cwd: '.tmp/styles/',
-          src: '{,*/}*.css',
-          dest: '.tmp/styles/'
+          cwd: '.tmp/styles',
+          src: '{.*/}*.css',
+          dest: '.tmp/styles'
         }]
       }
     },
@@ -516,7 +518,7 @@ module.exports = function (grunt) {
       'clean:server',
       'wiredep',
       'concurrent:server',
-      'autoprefixer:server',
+      'postcss:server',
       'connect:livereload',
       'watch'
     ]);
@@ -531,7 +533,7 @@ module.exports = function (grunt) {
     'clean:server',
     'wiredep',
     'concurrent:test',
-    'autoprefixer',
+    'postcss',
     'connect:test',
     'karma'
   ]);
@@ -541,7 +543,7 @@ module.exports = function (grunt) {
     'wiredep',
     'useminPrepare',
     'concurrent:dist',
-    'autoprefixer',
+    'autocss',
     'ngtemplates',
     'concat',
     'ngAnnotate',

--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -177,17 +177,17 @@ module.exports = function (grunt) {
         },
         files: [{
           expand: true,
-          cwd: '.tmp/styles',
+          cwd: '.tmp/styles/',
           src: '{,*/}*.css',
-          dest: '.tmp/styles'
+          dest: '.tmp/styles/'
         }]
       },
       dist: {
         files: [{
           expand: true,
-          cwd: '.tmp/styles',
+          cwd: '.tmp/styles/',
           src: '{,*/}*.css',
-          dest: '.tmp/styles'
+          dest: '.tmp/styles/'
         }]
       }
     },

--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -186,7 +186,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '.tmp/styles',
-          src: '{.*/}*.css',
+          src: '{,*/}*.css',
           dest: '.tmp/styles'
         }]
       }

--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -2,6 +2,7 @@
   "name": "<%= _.slugify(appname) %>",
   "private": true,
   "devDependencies": {
+    "autoprefixer-core": "^5.2.1",
     "grunt": "^0.4.5",
     "grunt-angular-templates": "^0.5.7",
     "grunt-autoprefixer": "^2.0.0",
@@ -22,6 +23,7 @@
     "grunt-google-cdn": "^0.4.3",
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
+    "grunt-postcss": "^0.5.5",
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
     "grunt-wiredep": "^2.0.0",

--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -5,7 +5,6 @@
     "autoprefixer-core": "^5.2.1",
     "grunt": "^0.4.5",
     "grunt-angular-templates": "^0.5.7",
-    "grunt-autoprefixer": "^2.0.0",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",<% if (coffee) { %>
     "grunt-contrib-coffee": "^0.12.0",<% } %><% if (compass) { %>


### PR DESCRIPTION
Upgrading grunt-autoprefixer to grunt-postcss, minimal changes added new npm post-css dependencies and removed deprecated grunt-autoprefixer.  Fixes #1132