### PR TITLE
fix(gulp): typo

### DIFF
--- a/templates/common/root/_gulpfile.js
+++ b/templates/common/root/_gulpfile.js
@@ -213,7 +213,7 @@ gulp.task('copy:fonts', function () {
 });
 
 gulp.task('build', ['clean:dist'], function () {
-  runSequence(['images', 'copy:extras', 'copy:fonts', 'client:build');
+  runSequence(['images', 'copy:extras', 'copy:fonts', 'client:build']);
 });
 
 gulp.task('default', ['build']);


### PR DESCRIPTION
Fixed typo on gulp build task, square bracket was missing.