### PR TITLE
Upgrade gulp-useref version and gulp task to 3.0.

### DIFF
--- a/templates/common/root/_gulpfile.js
+++ b/templates/common/root/_gulpfile.js
@@ -172,7 +172,7 @@ gulp.task('client:build', ['html', 'styles'], function () {
   var cssFilter = $.filter('**/*.css');
 
   return gulp.src(paths.views.main)
-    .pipe($.useref.assets({searchPath: [yeoman.app, '.tmp']}))
+    .pipe($.useref({searchPath: [yeoman.app, '.tmp']}))
     .pipe(jsFilter)
     .pipe($.ngAnnotate())
     .pipe($.uglify())
@@ -181,9 +181,7 @@ gulp.task('client:build', ['html', 'styles'], function () {
     .pipe($.minifyCss({cache: true}))
     .pipe(cssFilter.restore())
     .pipe($.rev())
-    .pipe($.useref.restore())
     .pipe($.revReplace())
-    .pipe($.useref())
     .pipe(gulp.dest(yeoman.dist));
 });
 

--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -17,7 +17,7 @@
     "gulp-rev": "^5.0.1",
     "gulp-rev-replace": "^0.4.2",
     "gulp-uglify": "^1.2.0",
-    "gulp-useref": "^1.2.0",
+    "gulp-useref": "^3.0.0",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.2.4",
     "run-sequence": "^1.1.1",


### PR DESCRIPTION
Upgrading the gulp-useref plugin to version 3.0.

3.0 has a simpler API. It only uses one stream now for html and assets so it simplifies the gulp task quite a bit.