### PR TITLE
Fix mixed return types in the default Gruntfile.js template

### DIFF
--- a/templates/common/root/_Gruntfile.js
+++ b/templates/common/root/_Gruntfile.js
@@ -573,18 +573,18 @@ module.exports = function (grunt) {
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
     if (target === 'dist') {
-      return grunt.task.run(['build', 'connect:dist:keepalive']);
+      grunt.task.run(['build', 'connect:dist:keepalive']);
+    } else {
+      grunt.task.run([
+        'clean:server',
+        'wiredep',<% if (typescript) { %>
+        'tsd:refresh',<% } %>
+        'concurrent:server',
+        'postcss:server',
+        'connect:livereload',
+        'watch'
+      ]);
     }
-
-    grunt.task.run([
-      'clean:server',
-      'wiredep',<% if (typescript) { %>
-      'tsd:refresh',<% } %>
-      'concurrent:server',
-      'postcss:server',
-      'connect:livereload',
-      'watch'
-    ]);
   });
 
   grunt.registerTask('server', 'DEPRECATED TASK. Use the "serve" task instead', function (target) {


### PR DESCRIPTION
My linter complained that depending on the code path the return type was different.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/yeoman/generator-angular/1223)
<!-- Reviewable:end -->
