### PR TITLE
chore(deps): Update grunt-typescript to v0.8.0

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -52,7 +52,7 @@
     "grunt-postcss": "^0.5.5",
     "grunt-svgmin": "^2.0.0",<% if (typescript) { %>
     "grunt-tsd": "^0.1.0",
-    "grunt-typescript": "^0.6.2",<% } %>
+    "grunt-typescript": "^0.8.0",<% } %>
     "grunt-usemin": "^3.0.0",
     "grunt-wiredep": "^2.0.0",
     "jit-grunt": "^0.9.1",


### PR DESCRIPTION
A fix to #1224 .

I came across this issue in importing `lodash.d.ts`. A new syntax of intersection type was introduced in typescript 1.6, and is used in latest lodash's definition file, but compiling it with current grunt-typescript (0.6.2) will throw a error.