### PR TITLE
Include note about the requirement of Ruby and compass gem

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Install `yo`, `grunt-cli`, `bower`, `generator-angular` and `generator-karma`:
 npm install -g grunt-cli bower yo generator-karma generator-angular
 ```
 
-Install Ruby (required in order to install compass which is used by this generator)
+Install Ruby and the compass gem. (sass may be deselected later) -
 - Download Ruby here:   http://rubyinstaller.org/downloads/. 
 - Once Ruby is installed, install the compass gem:
 ```

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,13 @@ Install `yo`, `grunt-cli`, `bower`, `generator-angular` and `generator-karma`:
 npm install -g grunt-cli bower yo generator-karma generator-angular
 ```
 
+Install Ruby (required in order to install compass which is used by this generator)
+- Download Ruby here:   http://rubyinstaller.org/downloads/. 
+- Once Ruby is installed, install the compass gem:
+```
+gem install compass
+```
+
 Make a new directory, and `cd` into it:
 ```
 mkdir my-new-project && cd $_


### PR DESCRIPTION
compass (Compass Stylesheet Authoring Framework) commands are used by this generator, however, there where no instructions on how to install compass. This tool does seems to be only be available with the installation of Ruby.