### PR TITLE
gulp bower error fix. move bower_components inside app/ and change in .bowercc and gulpfile

### DIFF
--- a/templates/common/root/_bowerrc
+++ b/templates/common/root/_bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "bower_components"
+  "directory": "app/bower_components"
 }

--- a/templates/common/root/_gulpfile.js
+++ b/templates/common/root/_gulpfile.js
@@ -156,7 +156,7 @@ gulp.task('bower', function () {
       directory: yeoman.app + '/bower_components',
       ignorePath: '..'
     }))
-  .pipe(gulp.dest(yeoman.app + '/views'));
+  .pipe(gulp.dest(yeoman.app));
 });
 
 ///////////


### PR DESCRIPTION
error: angular file not install..

fix: change in destination of bower_components to inside app/ , by changing in .bowercc
.bowercc: change-- "directory": "bower_components" to "directory": "app/bower_components"

and change the 'bower' task in gulpfile.: 
change-- ".pipe(gulp.dest(yeoman.app + '/views'));" to ".pipe(gulp.dest(yeoman.app));"
