### PR TITLE
Fix bower_components issue

### DIFF
--- a/templates/common/root/_gulpfile.js
+++ b/templates/common/root/_gulpfile.js
@@ -81,12 +81,12 @@ gulp.task('clean:tmp', function (cb) {
 });
 
 gulp.task('start:client', ['start:server', <% if (coffee) { %>'coffee', <% } %>'styles'], function () {
-  openURL('http://localhost:9000');
+  openURL('http://localhost:9000/app');
 });
 
 gulp.task('start:server', function() {
   $.connect.server({
-    root: [yeoman.app, '.tmp'],
+    root: '.',
     livereload: true,
     // Change this to '0.0.0.0' to access the server from outside.
     port: 9000
@@ -153,10 +153,10 @@ gulp.task('test', ['start:server:test'], function () {
 gulp.task('bower', function () {
   return gulp.src(paths.views.main)
     .pipe(wiredep({
-      directory: yeoman.app + '/bower_components',
+      directory: './bower_components',
       ignorePath: '..'
     }))
-  .pipe(gulp.dest(yeoman.app + '/views'));
+  .pipe(gulp.dest(yeoman.app));
 });
 
 ///////////


### PR DESCRIPTION
`bower_components` was migrated to project root, but that path in `bower` task still points to `/app/bower_components`. This PR fixes this issue. Also changed root of dev server to project root, otherwise `bower_components` won't be found.

Also fixed issue in #1261