### PR TITLE
fix(gen): fix missing grunt-karma dependency

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -47,6 +47,7 @@
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",<% if (!coffee) { %>
     "grunt-jscs": "^1.8.0",<% } %>
+    "grunt-karma": "^0.12.2",
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^0.9.2",
     "grunt-postcss": "^0.5.5",


### PR DESCRIPTION
Add the missing "grunt-karma" dependency to the generated "package.json" file when using Grunt

Closes #793, #1303