### PR TITLE
fix(gen:route) fix controller alias

### DIFF
--- a/route/index.js
+++ b/route/index.js
@@ -64,7 +64,7 @@ Generator.prototype.rewriteAppJs = function () {
     splicable: [
       "  templateUrl: 'views/" + this.name.toLowerCase() + ".html'" + (coffee ? "" : "," ),
       "  controller: '" + this.classedName + "Ctrl'" + (coffee ? "" : ","),
-      "  controllerAs: '" + this.cameledName + "'"
+      "  controllerAs: '" + this.cameledName.substr(this.cameledName.lastIndexOf('/') + 1) + "'"
     ]
   };
 


### PR DESCRIPTION
remove prefix `a/` from controller alias in routes like `a/b`.
