### PR TITLE
fix 404 errors on bower_components with Gulp on Windows

### DIFF
--- a/templates/common/root/_gulpfile.js
+++ b/templates/common/root/_gulpfile.js
@@ -8,6 +8,7 @@ var lazypipe = require('lazypipe');
 var rimraf = require('rimraf');
 var wiredep = require('wiredep').stream;
 var runSequence = require('run-sequence');
+var st = require('st');
 
 var yeoman = {
   app: require('./bower.json').appPath || 'app',
@@ -89,7 +90,12 @@ gulp.task('start:server', function() {
     root: [yeoman.app, '.tmp'],
     livereload: true,
     // Change this to '0.0.0.0' to access the server from outside.
-    port: 9000
+    port: 9000,
+    middleware: function (connect, opt) {
+            return [
+                st({ path: 'bower_components', url: '/bower_components' })
+            ];
+        }
   });
 });
 
@@ -136,7 +142,12 @@ gulp.task('serve:prod', function() {
   $.connect.server({
     root: [yeoman.dist],
     livereload: true,
-    port: 9000
+    port: 9000,
+    middleware: function (connect, opt) {
+            return [
+                st({ path: 'bower_components', url: '/bower_components' })
+            ];
+        }
   });
 });
 

--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -57,7 +57,8 @@
     "grunt-wiredep": "^2.0.0",
     "jit-grunt": "^0.9.1",
     "time-grunt": "^1.0.0"<% } %>,
-    "jshint-stylish": "^1.0.0"
+    "jshint-stylish": "^1.0.0",
+    "st": "^1.1.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
fix(app): fix 404 errors on bower_components with Gulp on Windows


With Gulp, the serve command don't expose symlink (or virtual dir) to bower_components on windows, so http://localhost:9000/bower_components/any_component/aa.js return a 404 error

This fix make "bower_component" a virutal dir for static file via "st" module as middleware for "connect" module.
Now it works.

I have no test actually.