### PR TITLE
add support for angular component

### DIFF
--- a/component/index.js
+++ b/component/index.js
@@ -1,0 +1,18 @@
+'use strict';
+var util = require('util');
+var ScriptBase = require('../script-base.js');
+
+var Generator = module.exports = function Generator() {
+  ScriptBase.apply(this, arguments);
+};
+
+util.inherits(Generator, ScriptBase);
+
+Generator.prototype.createComponentFiles = function createComponentFiles() {
+  this.generateSourceAndTest(
+    'component',
+    'spec/component',
+    'components',
+    this.options['skip-add'] || false
+  );
+};

--- a/readme.md
+++ b/readme.md
@@ -139,10 +139,10 @@ yo angular:component myComponent
 Produces `app/scripts/components/myComponent.js`:
 ```javascript
 angular.module('myMod').component('myComponent', {
-    template: '<div>{{$ctrl.message}}',
-    controller: function () {
-        this.message = 'this is the myComponent component';
-    }
+  template: '<div>{{$ctrl.message}}</div>',
+  controller: function () {
+    this.message = 'this is the myComponent component';
+  }
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ Available generators:
 * [angular](#app) (aka [angular:app](#app))
 * [angular:controller](#controller)
 * [angular:directive](#directive)
+* [angular:component](#component)
 * [angular:filter](#filter)
 * [angular:route](#route)
 * [angular:service](#service)
@@ -124,6 +125,24 @@ angular.module('myMod').directive('myDirective', function () {
       element.text('this is the myDirective directive');
     }
   };
+});
+```
+
+### Component
+Generates a component in `app/scripts/components`.
+
+Example:
+```bash
+yo angular:component myComponent
+```
+
+Produces `app/scripts/components/myComponent.js`:
+```javascript
+angular.module('myMod').component('myComponent', {
+    template: '<div>{{$ctrl.message}}',
+    controller: function () {
+        this.message = 'this is the myComponent component';
+    }
 });
 ```
 

--- a/templates/coffeescript/component.coffee
+++ b/templates/coffeescript/component.coffee
@@ -1,0 +1,14 @@
+'use strict'
+
+###*
+ # @ngdoc component
+ # @name <%= scriptAppName %>.component:<%= cameledName %>
+ # @description
+ # # <%= cameledName %>
+###
+angular.module '<%= scriptAppName %>'
+  .component '<%= cameledName %>',
+    template: '<div>{{$ctrl.message}}</div>'
+    controller: ->
+      this.message = 'this is the <%= cameledName %> component'
+      return

--- a/templates/coffeescript/spec/component.coffee
+++ b/templates/coffeescript/spec/component.coffee
@@ -1,0 +1,18 @@
+
+'use strict'
+
+describe 'Component: <%= cameledName %>', ->
+
+  # load the component's module
+  beforeEach module '<%= scriptAppName %>'
+
+  scope = {}
+
+  beforeEach inject ($rootScope) ->
+    scope = $rootScope.$new()
+
+  it 'should make hidden element visible', inject ($compile) ->
+    element = angular.element '<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>'
+    element = $compile(element) scope
+    scope.$apply()
+    expect(element.text()).toBe 'this is the <%= cameledName %> component'

--- a/templates/common/root/_bower.json
+++ b/templates/common/root/_bower.json
@@ -1,4 +1,4 @@
-{<% var ngVer = "1.4.0" %>
+{<% var ngVer = "1.5.7" %>
   "name": "<%= _.slugify(_.humanize(appname)) %>",
   "version": "0.0.0",
   "dependencies": {

--- a/templates/javascript/component.js
+++ b/templates/javascript/component.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * @ngdoc component
+ * @name <%= scriptAppName %>.component:<%= cameledName %>
+ * @description
+ * # <%= cameledName %>
+ */
+angular.module('<%= scriptAppName %>')
+  .component('<%= cameledName %>', {
+    template: '<div>{{$ctrl.message}}</div>',
+    controller: function () {
+      this.message = 'this is the <%= cameledName %> component';
+    }
+  });

--- a/templates/javascript/spec/component.js
+++ b/templates/javascript/spec/component.js
@@ -1,0 +1,20 @@
+'use strict';
+
+describe('Component: <%= cameledName %>', function () {
+
+  // load the components's module
+  beforeEach(module('<%= scriptAppName %>'));
+
+  var element, scope;
+
+  beforeEach(inject(function ($rootScope) {
+    scope = $rootScope.$new();
+  }));
+
+  it('should make hidden element visible', inject(function ($compile) {
+    element = angular.element('<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>');
+    element = $compile(element)(scope);
+    scope.$apply();
+    expect(element.text()).toBe('this is the <%= cameledName %> component');
+  }));
+});

--- a/test/component.js
+++ b/test/component.js
@@ -1,0 +1,22 @@
+'use strict';
+var fs = require('fs');
+var path = require('path');
+var helpers = require('yeoman-test');
+var assert = require('yeoman-assert');
+
+describe('angular:component', function () {
+  beforeEach(function (done) {
+    helpers
+      .run(require.resolve('../component'))
+      .withArguments('foo')
+      .on('end', done);
+  });
+
+  it('generates a new component', function () {
+    assert.file('test/spec/components/foo.js');
+    assert.fileContent(
+      path.join('app/scripts/components/foo.js'),
+      /component\('foo'/
+    );
+  });
+});


### PR DESCRIPTION
This PR bumps up the angular version to 1.5.7 so it is possible to create angular components. 
It also includes:
- Templates for component and test in JavaScript
- Templates for component and test in CoffeeScript

Templates for TypeScript haven't been included since changes in the type definitions are required.
