### PR TITLE
create link to list of generators at Yeoman.io in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
 
 > Yeoman generator for AngularJS - lets you quickly set up a project with sensible defaults and best practices.
 
-There are many starting points for building a new Angular single page app, in addition to this one. To see a comparison 
-of the popular options, have a look at 
-[this comparison](http://www.dancancro.com/comparison-of-angularjs-application-starters).
+There are many starting points for building a new Angular single page app, in addition to this one. You can find
+other options in this list at 
+[Yeoman.io](http://yeoman.io/generators).
 
 [Roadmap for upcoming plans/features/fixes](https://github.com/yeoman/generator-angular/issues/553)
 


### PR DESCRIPTION
Delete comparison link which is not directly functional and replace with link to a list that contains optional generators.
