### PR TITLE
fix(deps): update grunt-contrib-cssmin to 1.0.2

### DIFF
--- a/templates/common/root/_package.json
+++ b/templates/common/root/_package.json
@@ -38,7 +38,7 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "^0.7.0",
-    "grunt-contrib-cssmin": "^0.12.0",
+    "grunt-contrib-cssmin": "^1.0.2",
     "grunt-contrib-htmlmin": "^0.4.0",
     "grunt-contrib-imagemin": "^1.0.0",
     "grunt-contrib-jshint": "^0.11.0",


### PR DESCRIPTION
grunt-contrib-cssmin <1.0.2 issue with node v6: [link](https://github.com/gruntjs/grunt-contrib-cssmin/pull/271/commits/11e655873dfa58b6edcda0113cee612f7a6b2ab9?diff=split) 

Fixes: #1320
