### PR TITLE
fix(url contain '%2F' instead of '/')

### DIFF
--- a/templates/javascript/app.js
+++ b/templates/javascript/app.js
@@ -10,7 +10,7 @@
  */
 angular
   .module('<%= scriptAppName %>', [<%= angularModules %>])<% if (ngRoute) { %>
-  .config(function ($routeProvider) {
+  .config(function ($routeProvider, $locationProvider) {
     $routeProvider
       .when('/', {
         templateUrl: 'views/main.html',
@@ -20,4 +20,6 @@ angular
       .otherwise({
         redirectTo: '/'
       });
+
+    $locationProvider.hashPrefix('');
   })<% } %>;


### PR DESCRIPTION
Starting with Angular v.1.6.0, the default hash-prefix used for $location hash-bang URLs has changed from the empty string ('') to the bang ('!').
This means that the links from an app created with "yo angular" won't work, since Angular ^1.4.0 will resolve to angular 1.6.0 or newer.
I believe most people prefer to keep the # symbol instead of #!

Closes #1380 