### PR TITLE
fix bower_component loading problem on _gulpfile template

### DIFF
--- a/templates/common/root/_gulpfile.js
+++ b/templates/common/root/_gulpfile.js
@@ -89,7 +89,10 @@ gulp.task('start:server', function() {
     root: [yeoman.app, '.tmp'],
     livereload: true,
     // Change this to '0.0.0.0' to access the server from outside.
-    port: 9000
+    port: 9000,
+    middleware: function (connect) {
+      return [connect().use('/bower_components', connect.static('bower_components'))];
+    }
   });
 });
 
@@ -97,7 +100,10 @@ gulp.task('start:server:test', function() {
   $.connect.server({
     root: ['test', yeoman.app, '.tmp'],
     livereload: true,
-    port: 9001
+    port: 9001,
+    middleware: function (connect) {
+      return [connect().use('/bower_components', connect.static('bower_components'))];
+    }
   });
 });
 
@@ -105,6 +111,10 @@ gulp.task('watch', function () {
   $.watch(paths.styles)
     .pipe($.plumber())
     .pipe(styles())
+    .pipe($.connect.reload());
+
+  $.watch(paths.views.main)
+    .pipe($.plumber())
     .pipe($.connect.reload());
 
   $.watch(paths.views.files)
@@ -153,10 +163,10 @@ gulp.task('test', ['start:server:test'], function () {
 gulp.task('bower', function () {
   return gulp.src(paths.views.main)
     .pipe(wiredep({
-      directory: yeoman.app + '/bower_components',
+      directory: 'bower_components',
       ignorePath: '..'
     }))
-  .pipe(gulp.dest(yeoman.app + '/views'));
+    .pipe(gulp.dest(yeoman.app));
 });
 
 ///////////


### PR DESCRIPTION
**Before**:

- All the packages installed via bower were not automatically inserted into `index.html`.  The reason is `wiredep` is not properly configured with the proper path to `bower_components`. 

- In addition, the server middleware was also not configured to use `bower_components` so even if users add the script tags to packages in `bower_components` manually, the server would return `404 not found` to the browser requests.
 
- A final problem addressed in this pull request is  that the `watch` task was not monitoring `index.html` so the browser was not refreshing when that was changed.

The consequence of these problems is when running `gulp serve`, the user is met with a page that has no `css` and no `js` libraries. 


**After**: 
•	Fixed `wiredep` directory to proper location (outside of the app folder)
•	Started watching `index.html` (via paths.views.main)
•	Added bower_component as a resource for the server middleware

